### PR TITLE
MPI: allow to search for mpi and check if it matches CXX

### DIFF
--- a/common/cmake/ALPSTestMPI.cmake
+++ b/common/cmake/ALPSTestMPI.cmake
@@ -20,12 +20,12 @@ if (ENABLE_MPI)
 
     find_package(MPI REQUIRED)
 
-    set(mpi_is_ok true)
+    set(mpi_is_ok false)
     # check that the versions of compilers are the same
     execute_process(COMMAND ${MPI_CXX_COMPILER}   "-dumpversion" OUTPUT_VARIABLE mpi_version OUTPUT_STRIP_TRAILING_WHITESPACE)
     execute_process(COMMAND ${CMAKE_CXX_COMPILER} "-dumpversion" OUTPUT_VARIABLE cxx_version OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if (NOT ${mpi_version} EQUAL ${cxx_version})
-        set(mpi_is_ok false)
+    if (${mpi_version} EQUAL ${cxx_version})
+        set(mpi_is_ok true)
     endif()
 
     if (mpi_is_ok)


### PR DESCRIPTION
Here's a small update from me to allow to search for an mpi cxx compiler (handy on simple machines). 
The version check disallows the use of MPI compiler if it is not the same as the CXX one. 

(Also a check of pull requests)
