### PR TITLE
fix tests running with mvapich2.

### DIFF
--- a/common/cmake/ALPSEnableTests.cmake
+++ b/common/cmake/ALPSEnableTests.cmake
@@ -84,7 +84,7 @@ function(alps_add_gtest test)
     # FIXME: if compiler supports MPI directly, the MPIEXEC program is not deduced!
     # FIXME: in the MPI test command, POSIX shell is assumed
     if (partest AND MPIEXEC)
-        set(cmd "/bin/sh" "-c" "${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} \${ALPS_TEST_MPI_NPROC:-1} ${MPIEXEC_PREFLAGS} ${test} ${MPIEXEC_POSTFLAGS} ${test_xml_output}")
+        set(cmd "/bin/sh" "-c" "${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} \${ALPS_TEST_MPI_NPROC:-1} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${test}> ${MPIEXEC_POSTFLAGS} ${test_xml_output}")
     else()
         set(cmd ${test} ${test_xml_output})
     endif()


### PR DESCRIPTION
 we noticed tests failing because the binary was not found.