### PR TITLE
Fixed possible MPI deadlock in mcmpiadapter

### DIFF
--- a/mc/include/alps/mc/mpiadapter.hpp
+++ b/mc/include/alps/mc/mpiadapter.hpp
@@ -67,16 +67,21 @@ namespace alps {
             typename Base::results_type collect_results(typename Base::result_names_type const & names) const {
                 typename Base::results_type partial_results;
                 for(typename Base::result_names_type::const_iterator it = names.begin(); it != names.end(); ++it) {
-                    if (communicator.rank() == 0) {
-                        if (this->measurements[*it].count()) {
+                    const size_t sum_counts =
+                            alps::alps_mpi::all_reduce(communicator,
+                                                       static_cast<size_t>(this->measurements[*it].count() > 0 ? 1 : 0),
+                                                       std::plus<size_t>());
+                    if (sum_counts == communicator.size()) {
+                        if (communicator.rank() == 0) {
                             typename Base::observable_collection_type::value_type merged = this->measurements[*it];
                             merged.collective_merge(communicator, 0);
                             partial_results.insert(*it, merged.result());
-                        } else
-                          // FIXME: throw exception here instead
-                            partial_results.insert(*it, this->measurements[*it].result());
-                    } else if (this->measurements[*it].count())
-                        this->measurements[*it].collective_merge(communicator, 0);
+                        } else {
+                            this->measurements[*it].collective_merge(communicator, 0);
+                        }
+                    } else if (sum_counts > 0 && sum_counts < communicator.size()) {
+                        throw std::runtime_error(*it + " was measured on only some of the MPI processes.");
+                    }
                 }
                 return partial_results;
             }

--- a/mc/test/CMakeLists.txt
+++ b/mc/test/CMakeLists.txt
@@ -16,6 +16,7 @@ set (test_src_mpi
     reduce
     signed_obs
     custom_scheduler
+    reduce_unavailable_results
     )
 foreach(test ${test_src_mpi})
     alps_add_gtest(${test} NOMAIN PARTEST)

--- a/mc/test/reduce_unavailable_results.cpp
+++ b/mc/test/reduce_unavailable_results.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 1998-2016 ALPS Collaboration. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ * For use in publications, see ACKNOWLEDGE.TXT
+ */
+
+#include <alps/mc/mcbase.hpp>
+#include <alps/mc/mpiadapter.hpp>
+#include <alps/mc/api.hpp>
+#include <alps/mc/stop_callback.hpp>
+
+#include "alps/utilities/mpi.hpp"
+
+#include <alps/utilities/boost_mpi.hpp>
+#include <alps/accumulators.hpp>
+#include <alps/params.hpp>
+
+#include "alps/utilities/gtest_par_xml_output.hpp"
+#include "gtest/gtest.h"
+//#include "mpi_guard.hpp"
+
+class sim1 : public alps::mcbase {
+    public:
+        
+        sim1(parameters_type const & p, std::size_t seed_offset = 0):
+            alps::mcbase(p, seed_offset),
+            nsweeps(p["nsweeps"]), 
+            count(0),
+            measuring(p["measuring"]),
+            comm()
+        {
+            measurements << alps::accumulators::NoBinningAccumulator<std::vector<double> >("e1");
+        }
+ 
+        void update() {
+            count++;
+        }
+
+        void measure() {
+            if (measuring) {
+              measurements["e1"] << std::vector<double>(5, 1.0);
+            }
+        }
+
+        double fraction_completed() const { return (1.*count)/nsweeps; }
+ 
+    private:
+        int nsweeps;
+        int count;
+        bool measuring;
+        alps::mpi::communicator comm;
+};
+
+TEST(mc, reduce_unavailable_results_test){
+        alps::mpi::communicator c;
+        alps::mcbase::parameters_type p;
+
+        p["nsweeps"] = 100;
+        sim1::define_parameters(p); // do parameters definitions
+
+        if (c.size() > 1) {
+            //measurement only on master process (it should throw)
+            {
+                p["measuring"] = (c.rank() == 0);
+                alps::mcmpiadapter<sim1> sim(p, c, alps::check_schedule(0.001, 60));
+                sim.run(alps::stop_callback(1));
+                c.barrier();
+                ASSERT_ANY_THROW({
+                                     if (c.rank() == 0) {
+                                         alps::results_type<sim1>::type res = alps::collect_results(sim);
+                                     } else {
+                                         alps::collect_results(sim);
+                                     }
+                                 });
+            }
+
+
+            //not measured on any process (it should NOT throw)
+            {
+                p["measuring"] = false;
+                alps::mcmpiadapter<sim1> sim(p, c, alps::check_schedule(0.001, 60));
+                sim.run(alps::stop_callback(1));
+                c.barrier();
+                ASSERT_NO_THROW({
+                                    if (c.rank() == 0) {
+                                        alps::results_type<sim1>::type res = alps::collect_results(sim);
+                                    } else {
+                                        alps::collect_results(sim);
+                                    }
+                                });
+            }
+
+
+            //measured on all processes (it should NOT throw)
+            {
+                p["measuring"] = true;
+                alps::mcmpiadapter<sim1> sim(p, c, alps::check_schedule(0.001, 60));
+                sim.run(alps::stop_callback(1));
+                c.barrier();
+                ASSERT_NO_THROW({
+                                    if (c.rank() == 0) {
+                                        alps::results_type<sim1>::type res = alps::collect_results(sim);
+                                    } else {
+                                        alps::collect_results(sim);
+                                    }
+                                });
+            }
+
+        }
+}
+
+int main(int argc, char* argv[]) {
+    alps::mpi::environment env(argc, argv);
+    alps::gtest_par_xml_output tweak;
+    tweak(alps::mpi::communicator().rank(), argc, argv);
+    ::testing::InitGoogleTest(&argc, argv);
+
+    const int MASTER = 0;
+    const int rc = RUN_ALL_TESTS();
+
+    return rc;
+}


### PR DESCRIPTION
To ensure backward compatibility, we simply ignore an observable which was not measured on any process.