### PR TITLE
Numerical basis

### DIFF
--- a/gf/include/alps/gf/mesh.hpp
+++ b/gf/include/alps/gf/mesh.hpp
@@ -9,7 +9,6 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/operators.hpp>
 #include <boost/type_traits/integral_constant.hpp>
-#include <boost/type_traits/is_same.hpp>
 
 #include <alps/hdf5/archive.hpp>
 #include <alps/hdf5/complex.hpp>
@@ -880,11 +879,6 @@ namespace alps {
                 ar[path+"/kind"] << "NUMERICAL_MESH";
                 ar[path+"/N"] << dim_;
                 ar[path+"/k"] << k;
-                if (boost::is_same<T,double>::value) {
-                    ar[path+"/scalar_type"] << "double";
-                } else if (boost::is_same<T,std::complex<double> >::value) {
-                    ar[path+"/scalar_type"] << "complex_double";
-                }
                 ar[path+"/statistics"] << int(statistics_);
                 ar[path+"/beta"] << beta_;
                 for (int l=0; l < dim_; ++l) {
@@ -904,15 +898,6 @@ namespace alps {
                 ar[path+"/k"] >> k_tmp;
                 if (k != k_tmp) {
                     throw std::runtime_error("Attempt to read NUMERICAL_MESH mesh from data with different polynomial orders ="+boost::lexical_cast<std::string>(k_tmp));
-                }
-
-                {
-                    std::string type_str;
-                    ar[path+"/scalar_type"] >> type_str;
-                    if (!(boost::is_same<T,double>::value && type_str=="double")
-                                    && !(boost::is_same<T,std::complex<double> >::value && type_str=="complex_double")) {
-                        throw std::runtime_error("Attempt to read NUMERICAL_MESH mesh from data with scalar type ="+type_str);
-                    }
                 }
 
                 ar[path+"/N"] >> dim;

--- a/gf/include/alps/gf/piecewise_polynomial.hpp
+++ b/gf/include/alps/gf/piecewise_polynomial.hpp
@@ -1,0 +1,369 @@
+/*
+ * Copyright (C) 1998-2017 ALPS Collaboration. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ * For use in publications, see ACKNOWLEDGE.TXT
+ */
+
+#ifndef ALPSCORE_PIEACEWISE_POLYNOMIAL_HPP
+#define ALPSCORE_PIEACEWISE_POLYNOMIAL_HPP
+
+#include <complex>
+#include <cmath>
+#include <vector>
+
+#include <boost/multi_array.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/typeof/typeof.hpp>
+
+#include <alps/hdf5/archive.hpp>
+#include <alps/hdf5/complex.hpp>
+#include <alps/hdf5/vector.hpp>
+#include <alps/hdf5/multi_array.hpp>
+
+#ifdef ALPS_HAVE_MPI
+#include "mpi_bcast.hpp"
+#endif
+
+/**
+ * @brief Class representing a pieacewise polynomial and utilities
+ */
+namespace alps {
+    namespace gf {
+
+        template<typename T, int k>
+        class piecewise_polynomial;
+
+        namespace detail {
+            /**
+             *
+             * @tparam T double or std::complex<double>
+             * @param a  scalar
+             * @param b  scalar
+             * @return   conj(a) * b
+             */
+            template<class T>
+            typename boost::enable_if<boost::is_floating_point<T>, T>::type
+            outer_product(T a, T b) {
+                return a * b;
+            }
+
+            template<class T>
+            std::complex<T>
+            outer_product(const std::complex<T> &a, const std::complex<T> &b) {
+                return std::conj(a) * b;
+            }
+
+            template<class T>
+            typename boost::enable_if<boost::is_floating_point<T>, T>::type
+            conjg(T a) {
+                return a;
+            }
+
+            template<class T>
+            std::complex<T>
+            conjg(const std::complex<T> &a) {
+                return std::conj(a);
+            }
+        }
+
+/**
+ * Class for representing a piecewise polynomial
+ *   A function is represented by a polynomial in each section [x_n, x_{n+1}).
+ */
+        template<typename T, int k>
+        class piecewise_polynomial {
+        private:
+            typedef boost::multi_array<T, 2> coefficient_type;
+
+            template<typename TT, int kk>
+            friend piecewise_polynomial<TT, kk>
+            operator+(const piecewise_polynomial<TT, kk> &f1, const piecewise_polynomial<TT, kk> &f2);
+
+            template<typename TT, int kk>
+            friend piecewise_polynomial<TT, kk>
+            operator-(const piecewise_polynomial<TT, kk> &f1, const piecewise_polynomial<TT, kk> &f2);
+
+            template<typename TT, int kk>
+            friend const piecewise_polynomial<TT, kk> operator*(TT scalar, const piecewise_polynomial<TT, kk> &pp);
+
+            template<typename TT, int kk>
+            friend
+            class piecewise_polynomial;
+
+            /// number of sections
+            int n_sections_;
+
+            /// edges of sections. The first and last elements should be -1 and 1, respectively.
+            std::vector<double> section_edges_;
+
+            /// expansion coefficients [s,l]
+            /// The polynomial is represented as
+            ///   \sum_{l=0}^k a_{s,l} (x - x_s)^l,
+            /// where x_s is the left end point of the s-th section.
+            coefficient_type coeff_;
+
+            bool valid_;
+
+            void check_range(double x) const {
+                if (x < section_edges_[0] || x > section_edges_[section_edges_.size() - 1]) {
+                    throw std::runtime_error("Give x is out of the range.");
+                }
+            }
+
+            void check_validity() const {
+                if (!valid_) {
+                    throw std::runtime_error("pieacewise_polynomial object is not properly constructed!");
+                }
+            }
+
+            void set_validity() {
+                valid_ = true;
+                valid_ = valid_ && (n_sections_ >= 1);
+                assert(valid_);
+                valid_ = valid_ && (section_edges_.size() == n_sections_ + 1);
+                assert(valid_);
+                valid_ = valid_ && (coeff_.shape()[0] == n_sections_);
+                assert(valid_);
+                valid_ = valid_ && (coeff_.shape()[1] == k + 1);
+                assert(valid_);
+                for (int i = 0; i < n_sections_; ++i) {
+                    valid_ = valid_ && (section_edges_[i] < section_edges_[i + 1]);
+                }
+                assert(valid_);
+            }
+
+        public:
+            piecewise_polynomial() : n_sections_(0), valid_(false) {};
+
+            piecewise_polynomial(int n_section,
+                                 const std::vector<double> &section_edges,
+                                 const boost::multi_array<T, 2> &coeff) : n_sections_(section_edges.size() - 1),
+                                                                          section_edges_(section_edges),
+                                                                          coeff_(coeff), valid_(false) {
+                set_validity();
+                check_validity();
+            };
+
+            /// Number of sections
+            int num_sections() const {
+#ifndef NDEBUG
+                check_validity();
+#endif
+                return n_sections_;
+            }
+
+            /// Return an end point. The index i runs from 0 (smallest) to num_sections()+1 (largest).
+            inline double section_edge(int i) const {
+                assert(i >= 0 && i < section_edges_.size());
+#ifndef NDEBUG
+                check_validity();
+#endif
+                return section_edges_[i];
+            }
+
+            /// Return a refence to end points
+            const std::vector<double> &section_edges() const {
+#ifndef NDEBUG
+                check_validity();
+#endif
+                return section_edges_;
+            }
+
+            /// Return the coefficient of $x^p$ for the given section.
+            inline T coefficient(int i, int p) const {
+                assert(i >= 0 && i < section_edges_.size());
+                assert(p >= 0 && p <= k);
+#ifndef NDEBUG
+                check_validity();
+#endif
+                return coeff_[i][p];
+            }
+
+            /// Compute the value at x.
+            inline T compute_value(double x) const {
+#ifndef NDEBUG
+                check_validity();
+#endif
+                return compute_value(x, find_section(x));
+            }
+
+            /// Compute the value at x. x must be in the given section.
+            inline T compute_value(double x, int section) const {
+#ifndef NDEBUG
+                check_validity();
+#endif
+                if (x < section_edges_[section] || (x != section_edges_.back() && x >= section_edges_[section + 1])) {
+                    throw std::runtime_error("The given x is not in the given section.");
+                }
+
+                const double dx = x - section_edges_[section];
+                T r = 0.0, x_pow = 1.0;
+                for (int p = 0; p < k + 1; ++p) {
+                    r += coeff_[section][p] * x_pow;
+                    x_pow *= dx;
+                }
+                return r;
+            }
+
+            /// Find the section involving the given x
+            int find_section(double x) const {
+#ifndef NDEBUG
+                check_validity();
+#endif
+                if (x == section_edges_[0]) {
+                    return 0;
+                } else if (x == section_edges_.back()) {
+                    return coeff_.size() - 1;
+                }
+
+                std::vector<double>::const_iterator it =
+                        std::upper_bound(section_edges_.begin(), section_edges_.end(), x);
+                --it;
+                return (&(*it) - &(section_edges_[0]));
+            }
+
+            /// Compute overlap <this | other> with complex conjugate. The two objects must have the same sections.
+            template<class T2, int k2>
+            T overlap(const piecewise_polynomial<T2, k2> &other) const {
+                check_validity();
+                if (section_edges_ != other.section_edges_) {
+                    throw std::runtime_error("Computing overlap between piecewise polynomials with different section edges are not supported");
+                }
+                typedef BOOST_TYPEOF(static_cast<T>(1.0)*static_cast<T2>(1.0))  Tr;
+
+                Tr r = 0.0;
+                boost::array<double, k + k2 + 2> x_min_power, dx_power;
+
+                for (int s = 0; s < n_sections_; ++s) {
+                    dx_power[0] = 1.0;
+                    const double dx = section_edges_[s + 1] - section_edges_[s];
+                    for (int p = 1; p < dx_power.size(); ++p) {
+                        dx_power[p] = dx * dx_power[p - 1];
+                    }
+
+                    for (int p = 0; p < k + 1; ++p) {
+                        for (int p2 = 0; p2 < k2 + 1; ++p2) {
+                            r += detail::outer_product((Tr) coeff_[s][p], (Tr) other.coeff_[s][p2])
+                                 * dx_power[p + p2 + 1] / (p + p2 + 1.0);
+                        }
+                    }
+                }
+                return r;
+            }
+
+            /// Returns whether or not two objects are numerically the same.
+            bool operator==(const piecewise_polynomial<T, k> &other) const {
+                return (n_sections_ == other.n_sections_) &&
+                        (section_edges_ == other.section_edges_) &&
+                                (coeff_ == other.coeff_);
+            }
+
+            /// Save to a hdf5 file
+            void save(alps::hdf5::archive& ar, const std::string& path) const {
+                check_validity();
+                ar[path+"/k"] <<  k;
+                ar[path+"/num_sections"] << num_sections();
+                ar[path+"/section_edges"] << section_edges_;
+                ar[path+"/coefficients"] << coeff_;
+            }
+
+            /// Load from a hdf5 file
+            void load(alps::hdf5::archive& ar, const std::string& path) {
+                int k_tmp;
+                ar[path+"/k"] >>  k_tmp;
+                if (k != k_tmp) {
+                    throw std::runtime_error("Attempt to load data with different polynomial order k"+boost::lexical_cast<std::string>(k_tmp));
+                }
+                ar[path+"/num_sections"] >> n_sections_;
+                ar[path+"/section_edges"] >> section_edges_;
+                ar[path+"/coefficients"] >> coeff_;
+
+                set_validity();
+                check_validity();
+            }
+
+#ifdef ALPS_HAVE_MPI
+            /// Broadcast
+            void broadcast(const alps::mpi::communicator& comm, int root)
+            {
+                using alps::mpi::broadcast;
+
+                broadcast(comm, n_sections_, root);
+                section_edges_.resize(n_sections_+1);
+                broadcast(comm, &section_edges_[0], n_sections_+1, root);
+
+                coeff_.resize(boost::extents[n_sections_][k+1]);
+                broadcast(comm, coeff_.origin(), (k+1)*n_sections_, root);
+
+                set_validity();
+                check_validity();
+            }
+#endif
+
+        };//class pieacewise_polynomial
+
+/// Add piecewise_polynomial objects
+        template<typename T, int k>
+        piecewise_polynomial<T, k>
+        operator+(const piecewise_polynomial<T, k> &f1, const piecewise_polynomial<T, k> &f2) {
+            if (f1.section_edges_ != f2.section_edges_) {
+                throw std::runtime_error("Cannot add two numerical functions with different sections!");
+            }
+            boost::multi_array<T, 2> coeff_sum(f1.coeff_);
+            std::transform(
+                    f1.coeff_.origin(), f1.coeff_.origin() + f1.coeff_.num_elements(),
+                    f2.coeff_.origin(), coeff_sum.origin(),
+                    std::plus<T>()
+
+            );
+            return piecewise_polynomial<T, k>(f1.num_sections(), f1.section_edges_, coeff_sum);
+        }
+
+/// Substract piecewise_polynomial objects
+        template<typename T, int k>
+        piecewise_polynomial<T, k>
+        operator-(const piecewise_polynomial<T, k> &f1, const piecewise_polynomial<T, k> &f2) {
+            if (f1.section_edges_ != f2.section_edges_) {
+                throw std::runtime_error("Cannot add two numerical functions with different sections!");
+            }
+            boost::multi_array<T, 2> coeff_sum(f1.coeff_);
+            std::transform(
+                    f1.coeff_.origin(), f1.coeff_.origin() + f1.coeff_.num_elements(),
+                    f2.coeff_.origin(), coeff_sum.origin(),
+                    std::minus<T>()
+
+            );
+            return piecewise_polynomial<T, k>(f1.num_sections(), f1.section_edges_, coeff_sum);
+        }
+
+/// Multiply piecewise_polynomial by a scalar
+        template<typename T, int k>
+        const piecewise_polynomial<T, k> operator*(T scalar, const piecewise_polynomial<T, k> &pp) {
+            piecewise_polynomial<T, k> pp_copy(pp);
+            std::transform(
+                    pp_copy.coeff_.origin(), pp_copy.coeff_.origin() + pp_copy.coeff_.num_elements(),
+                    pp_copy.coeff_.origin(), std::bind1st(std::multiplies<T>(), scalar)
+
+            );
+            return pp_copy;
+        }
+
+/// Gram-Schmidt orthonormalization
+        template<typename T, int k>
+        void orthonormalize(std::vector<piecewise_polynomial<T, k> > &pps) {
+            typedef piecewise_polynomial<T, k> pp_type;
+
+            for (int l = 0; l < pps.size(); ++l) {
+                pp_type pp_new(pps[l]);
+                for (int l2 = 0; l2 < l; ++l2) {
+                    const T overlap = pps[l2].overlap(pps[l]);
+                    pp_new = pp_new - overlap * pps[l2];
+                }
+                double norm = pp_new.overlap(pp_new);
+                pps[l] = (1.0 / std::sqrt(norm)) * pp_new;
+            }
+        }
+    }
+}
+
+#endif //ALPSCORE_PIEACEWISE_POLYNOMIAL_HPP

--- a/gf/include/alps/gf/piecewise_polynomial.hpp
+++ b/gf/include/alps/gf/piecewise_polynomial.hpp
@@ -141,7 +141,7 @@ namespace alps {
                                                                           section_edges_(section_edges),
                                                                           coeff_(coeff), valid_(false) {
                 set_validity();
-                check_validity();
+                check_validity();//this may throw
             };
 
             /// Number of sections

--- a/gf/test/CMakeLists.txt
+++ b/gf/test/CMakeLists.txt
@@ -12,6 +12,7 @@ set (test_srcs
   itime_gf_test
   fourier_test
   grid_test
+  piecewise_polynomial_test
     )
 
 

--- a/gf/test/piecewise_polynomial_test.cpp
+++ b/gf/test/piecewise_polynomial_test.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 1998-2017 ALPS Collaboration. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ * For use in publications, see ACKNOWLEDGE.TXT
+ */
+
+#include "gtest/gtest.h"
+#include "alps/gf/piecewise_polynomial.hpp"
+#include <boost/filesystem/operations.hpp>
+
+TEST(PiecewisePolynomial, Orthogonalization) {
+    typedef double Scalar;
+    const int n_section = 10, k = 8, n_basis = 3;
+    typedef alps::gf::piecewise_polynomial<Scalar,k> pp_type;
+
+    std::vector<double> section_edges(n_section+1);
+    boost::multi_array<Scalar,3> coeff(boost::extents[n_basis][n_section][k+1]);
+
+    for (int s = 0; s < n_section + 1; ++s) {
+        section_edges[s] = s*2.0/n_section - 1.0;
+    }
+    section_edges[0] = -1.0;
+    section_edges[n_section] = 1.0;
+
+    std::vector<pp_type> nfunctions;
+
+    // x^0, x^1, x^2, ...
+    for (int n = 0; n < n_basis; ++ n) {
+        boost::multi_array<Scalar,2> coeff(boost::extents[n_section][k+1]);
+        std::fill(coeff.origin(), coeff.origin()+coeff.num_elements(), 0.0);
+
+        for (int s = 0; s < n_section; ++s) {
+            double rtmp = 1.0;
+            for (int l = 0; l < k + 1; ++l) {
+                if (n - l < 0) {
+                    break;
+                }
+                if (l > 0) {
+                    rtmp /= l;
+                    rtmp *= n + 1 - l;
+                }
+                coeff[s][l] = rtmp * std::pow(section_edges[s], n-l);
+            }
+        }
+
+        nfunctions.push_back(pp_type(n_section, section_edges, coeff));
+    }
+
+    // Check if correctly constructed
+    double x = 0.9;
+    for (int n = 0; n < n_basis; ++ n) {
+        EXPECT_NEAR(nfunctions[n].compute_value(x), std::pow(x, n), 1e-8);
+    }
+
+    // Check overlap
+    for (int n = 0; n < n_basis; ++ n) {
+        for (int m = 0; m < n_basis; ++ m) {
+            EXPECT_NEAR(nfunctions[n].overlap(nfunctions[m]), (std::pow(1.0,n+m+1)-std::pow(-1.0,n+m+1))/(n+m+1), 1e-8);
+        }
+    }
+
+
+    // Check plus and minus
+    for (int n = 0; n < n_basis; ++ n) {
+        EXPECT_NEAR(4 * nfunctions[n].compute_value(x), (4.0*nfunctions[n]).compute_value(x), 1e-8);
+        for (int m = 0; m < n_basis; ++m) {
+            EXPECT_NEAR(nfunctions[n].compute_value(x) + nfunctions[m].compute_value(x),
+                        (nfunctions[n] + nfunctions[m]).compute_value(x), 1e-8);
+            EXPECT_NEAR(nfunctions[n].compute_value(x) - nfunctions[m].compute_value(x),
+                        (nfunctions[n] - nfunctions[m]).compute_value(x), 1e-8);
+        }
+    }
+
+    alps::gf::orthonormalize(nfunctions);
+    for (int n = 0; n < n_basis; ++ n) {
+        for (int m = 0; m < n_basis; ++m) {
+            EXPECT_NEAR(nfunctions[n].overlap(nfunctions[m]),
+                        n == m ? 1.0 : 0.0,
+                        1e-8
+            );
+        }
+    }
+
+    //l = 0 should be x
+    EXPECT_NEAR(nfunctions[1].compute_value(x) * std::sqrt(2.0/3.0), x, 1E-8);
+}
+
+TEST(PiecewisePolynomial, SaveLoad) {
+    const int n_section = 2, k = 3;
+    typedef double Scalar;
+    typedef alps::gf::piecewise_polynomial<Scalar,k> pp_type;
+
+    std::vector<double> section_edges(n_section+1);
+    section_edges[0] = -1.0;
+    section_edges[1] =  0.0;
+    section_edges[2] =  1.0;
+    boost::multi_array<Scalar,2> coeff(boost::extents[n_section][k+1]);
+    std::fill(coeff.origin(), coeff.origin()+coeff.num_elements(), 0.0);
+
+    pp_type p(n_section, section_edges, coeff), p2;
+    {
+        alps::hdf5::archive oar("pp.h5","w");
+        p.save(oar,"/pp");
+
+    }
+
+    {
+        alps::hdf5::archive iar("pp.h5");
+        p2.load(iar,"/pp");
+    }
+    boost::filesystem::remove("pp.h5");
+
+    ASSERT_TRUE(p == p2);
+}
+


### PR DESCRIPTION
The essential change from the previous pull request is that I have removed "scalar_type" dataset in numerical_mesh. This pull request includes two commits. The timestamp of the elder one seems bit strange because I merged several comments into a single one using "rebase -i". It may throw in the constructor of pieacewise_polynomial (see the comment there).