### PR TITLE
Remove signal handlers for SIGSTOP and SIGKILL

### DIFF
--- a/utilities/src/signal.cpp
+++ b/utilities/src/signal.cpp
@@ -34,8 +34,6 @@ namespace alps {
                 sigaction(SIGQUIT, &action, NULL);
                 sigaction(SIGUSR1, &action, NULL);
                 sigaction(SIGUSR2, &action, NULL);
-                sigaction(SIGSTOP, &action, NULL);
-                sigaction(SIGKILL, &action, NULL);
             }
         #endif
         listen();


### PR DESCRIPTION
This removes the handlers for SIGSTOP and SIGKILL, which cannot be caught anyway.

Since valgrind complains when these handlers are present, we might as well remove them.