### PR TITLE
Workaround for a bug in intel compiler 12.0

### DIFF
--- a/accumulators/include/alps/accumulators/feature/binning_analysis.hpp
+++ b/accumulators/include/alps/accumulators/feature/binning_analysis.hpp
@@ -266,24 +266,24 @@ namespace alps {
 
                     template<typename S> void print(S & os, bool terse=false) const {
                         if (terse) {
-                            os << short_print(this->mean())
+                            os << alps::short_print(this->mean())
                                << " #" << this->count()
-                               << " +/-" << short_print(this->error())
-                               << " Tau:" << short_print(autocorrelation())
+                               << " +/-" << alps::short_print(this->error())
+                               << " Tau:" << alps::short_print(autocorrelation())
                                << " (warning: print result rather than accumulator)";
                         } else {
                             os << "DEBUG PRINTING of the accumulator object state (use mean(), error() and autocorrelation() methods instead)\n"
                                << "No-binning parent accumulator state:\n";
                             B::print(os, terse);
                             os << "\nLog-binning accumulator state:\n"
-                               << " Error bar: " << short_print(error())
-                               << " Autocorrelation: " << short_print(autocorrelation());
+                               << " Error bar: " << alps::short_print(error())
+                               << " Autocorrelation: " << alps::short_print(autocorrelation());
                             if (m_ac_sum2.size() > 0) {
                                 for (std::size_t i = 0; i < binning_depth(); ++i)
                                     os << std::endl
                                        << "    bin #" << std::setw(3) <<  i + 1
                                        << " : " << std::setw(8) << m_ac_count[i]
-                                       << " entries: error = " << short_print(error(i));
+                                       << " entries: error = " << alps::short_print(error(i));
                                 os << std::endl;
                             } else
                                 os << "No measurements" << std::endl;
@@ -446,18 +446,18 @@ namespace alps {
 
                     template<typename S> void print(S & os, bool terse=false) const {
                         if (terse) {
-                            os << short_print(this->mean())
+                            os << alps::short_print(this->mean())
                                << " #" << this->count()
-                               << " +/-" << short_print(this->error())
-                               << " Tau:" << short_print(autocorrelation());
+                               << " +/-" << alps::short_print(this->error())
+                               << " Tau:" << alps::short_print(autocorrelation());
                         } else {
-                            os << " Error bar: " << short_print(error());
-                            os << " Autocorrelation: " << short_print(autocorrelation());
+                            os << " Error bar: " << alps::short_print(error());
+                            os << " Autocorrelation: " << alps::short_print(autocorrelation());
                             if (m_ac_errors.size() > 0) {
                                 for (std::size_t i = 0; i < m_ac_errors.size(); ++i)
                                     os << std::endl
                                        << "    bin #" << std::setw(3) <<  i + 1
-                                       << " entries: error = " << short_print(m_ac_errors[i]);
+                                       << " entries: error = " << alps::short_print(m_ac_errors[i]);
                             } else {
                                 os << "No bins";
                             }

--- a/accumulators/include/alps/accumulators/feature/max_num_binning.hpp
+++ b/accumulators/include/alps/accumulators/feature/max_num_binning.hpp
@@ -70,12 +70,12 @@ namespace alps {
                         return os;
                     }
                     if (terse) {
-                        os << short_print(m_bins, 4) << "#" << m_num_elements;
+                        os << alps::short_print(m_bins, 4) << "#" << m_num_elements;
                         return os;
                     }
                     os << m_num_elements << " elements per bin, bins are:\n";
                     for (int i=0; i<m_bins.size(); ++i) {
-                        os << "#" << (i+1) << ": " << short_print(m_bins[i],4) << "\n";
+                        os << "#" << (i+1) << ": " << alps::short_print(m_bins[i],4) << "\n";
                     }
                     return os;
                 }
@@ -230,17 +230,17 @@ namespace alps {
 
                 template<typename S> void print(S & os, bool terse=false) const {
                     if (terse) {
-                        os << short_print(this->mean())
+                        os << alps::short_print(this->mean())
                            << " #" << this->count()
-                           << " +/-" << short_print(this->error())
-                           << " Tau:" << short_print(this->autocorrelation());
+                           << " +/-" << alps::short_print(this->error())
+                           << " Tau:" << alps::short_print(this->autocorrelation());
                     } else {
                         B::print(os, terse);
                         os << "Full-binning accumulator state:\n"
                            << "Mean +/-error (tau): "
-                           << short_print(this->mean())
-                           << " +/-" << short_print(this->error())
-                           << "(" << short_print(this->autocorrelation()) << ")\n";
+                           << alps::short_print(this->mean())
+                           << " +/-" << alps::short_print(this->error())
+                           << "(" << alps::short_print(this->autocorrelation()) << ")\n";
                         os << " Bins: ";
                         max_num_binning().print(os,false);
                     }
@@ -557,9 +557,9 @@ namespace alps {
                 template<typename S> void print(S & os, bool terse=false) const {
                     // TODO: use m_mn_variables!
                     os << "Mean +/-error (tau): "
-                       << short_print(mean())
-                       << " +/-" << short_print(error())
-                       << "(" << short_print(this->autocorrelation()) << ")";
+                       << alps::short_print(mean())
+                       << " +/-" << alps::short_print(error())
+                       << "(" << alps::short_print(this->autocorrelation()) << ")";
                     if (!terse) {
                         os << "\n Bins: " << max_num_binning();
                     }


### PR DESCRIPTION
To avoid name look-up errors. Even with this fix, ALPSCore does not compile with intel C++ compiler 12.0 due to an internal error.