### PR TITLE
Fixed bugs in numerical_mesh & piecewise_polynomial

### DIFF
--- a/gf/include/alps/gf/piecewise_polynomial.hpp
+++ b/gf/include/alps/gf/piecewise_polynomial.hpp
@@ -204,6 +204,18 @@ namespace alps {
                 check_validity();//this may throw
             };
 
+            /// Copy operator
+            piecewise_polynomial<T>& operator=(const piecewise_polynomial<T>& other) {
+                k_ = other.k_;
+                n_sections_ = other.n_sections_;
+                section_edges_ = other.section_edges_;
+                //Should be resized before a copy
+                coeff_.resize(boost::extents[other.coeff_.shape()[0]][other.coeff_.shape()[1]]);
+                coeff_ = other.coeff_;
+                valid_ = other.valid_;
+                return *this;
+            }
+
             /// Order of the polynomial
             int order() const {
                 return k_;
@@ -332,6 +344,11 @@ namespace alps {
                     }
                 }
                 return r;
+            }
+
+            /// Compute squared norm
+            double squared_norm() const {
+                return static_cast<double>(this->overlap(*this));
             }
 
             /// Returns whether or not two objects are numerically the same.

--- a/gf/test/piecewise_polynomial_test.cpp
+++ b/gf/test/piecewise_polynomial_test.cpp
@@ -113,3 +113,21 @@ TEST(PiecewisePolynomial, SaveLoad) {
     ASSERT_TRUE(p == p2);
 }
 
+TEST(PiecewisePolynomial, Copy) {
+    const int n_section = 2, k = 3;
+    typedef double Scalar;
+    typedef alps::gf::piecewise_polynomial<Scalar> pp_type;
+
+    std::vector<double> section_edges(n_section+1);
+    section_edges[0] = -1.0;
+    section_edges[1] =  0.0;
+    section_edges[2] =  1.0;
+    boost::multi_array<Scalar,2> coeff(boost::extents[n_section][k+1]);
+    std::fill(coeff.origin(), coeff.origin()+coeff.num_elements(), 0.0);
+
+    pp_type p(n_section, section_edges, coeff), p2;
+    EXPECT_NO_THROW({p2 = p;});
+
+    std::vector<pp_type> p_vec(1);
+    EXPECT_NO_THROW({p_vec[0] = p;});
+}

--- a/gf/test/piecewise_polynomial_test.cpp
+++ b/gf/test/piecewise_polynomial_test.cpp
@@ -127,7 +127,5 @@ TEST(PiecewisePolynomial, Copy) {
 
     pp_type p(n_section, section_edges, coeff), p2;
     EXPECT_NO_THROW({p2 = p;});
-
-    std::vector<pp_type> p_vec(1);
-    EXPECT_NO_THROW({p_vec[0] = p;});
+    EXPECT_TRUE(p2 == p);
 }


### PR DESCRIPTION
Fixed minor bugs. One of them originates from the boost::multi_array's design that we need to resize an object before copying another object into.