### PR TITLE
version of MPI_INIT with NULL as parameters (MPI standard 2)

### DIFF
--- a/utilities/include/alps/utilities/mpi.hpp
+++ b/utilities/include/alps/utilities/mpi.hpp
@@ -192,6 +192,14 @@ namespace alps {
                     initialized_=true;
                 }
             }
+            environment(bool abort_on_exception=true)
+                : initialized_(false), abort_on_exception_(abort_on_exception)
+            {
+                if (!initialized()) {
+                    MPI_Init(NULL,NULL);
+                    initialized_=true;
+                }
+            }
 
             ~environment()
             {


### PR DESCRIPTION
This is a version of MPI_INIT with NULL as parameters (MPI standard 2). It allows easier initialization of MPI e.g. for testing when no default environment arguments are available.