### PR TITLE
 Fixed crashes when running tests in parallel

### DIFF
--- a/accumulators/test/custom_type.cpp
+++ b/accumulators/test/custom_type.cpp
@@ -173,7 +173,7 @@ struct CustomTypeAccumulatorTest : public testing::Test {
     }
 
     void TestSaveAccumulator() {
-        const std::string fname="save_acc.h5";
+        const std::string fname="ct_save_acc.h5";
         std::remove(fname.c_str());
         const alps::accumulators::accumulator_set& m=acc_gen.accumulators();
         alps::hdf5::archive ar(fname,"w");
@@ -181,7 +181,7 @@ struct CustomTypeAccumulatorTest : public testing::Test {
     }
 
     void TestSaveResult() {
-        const std::string fname="save_res.h5";
+        const std::string fname="ct_save_res.h5";
         std::remove(fname.c_str());
         const alps::accumulators::result_set& res=acc_gen.results();
         alps::hdf5::archive ar(fname,"w");
@@ -189,7 +189,7 @@ struct CustomTypeAccumulatorTest : public testing::Test {
     }
 
     void TestSaveLoadAccumulator() {
-        const std::string fname="saveload_acc.h5";
+        const std::string fname="ct_saveload_acc.h5";
         std::remove(fname.c_str());
         const alps::accumulators::accumulator_set& m=acc_gen.accumulators();
         {
@@ -211,7 +211,7 @@ struct CustomTypeAccumulatorTest : public testing::Test {
     }
 
     void TestSaveLoadResult() {
-        const std::string fname="saveload_res.h5";
+        const std::string fname="ct_saveload_res.h5";
         std::remove(fname.c_str());
         const alps::accumulators::result_set& r=acc_gen.results();
         {

--- a/accumulators/test/save_load2.cpp
+++ b/accumulators/test/save_load2.cpp
@@ -43,7 +43,7 @@ struct AccumulatorTest : public testing::Test {
 
     /// Save accumulator
     void TestSaveAccumulator() {
-        const std::string fname="save_acc.h5";
+        const std::string fname="sl_save_acc.h5";
         std::remove(fname.c_str());
         const alps::accumulators::accumulator_set& m=acc_gen.accumulators();
         alps::hdf5::archive ar(fname,"w");
@@ -52,7 +52,7 @@ struct AccumulatorTest : public testing::Test {
 
     /// Save result set
     void TestSaveResult() {
-        const std::string fname="save_res.h5";
+        const std::string fname="sl_save_res.h5";
         std::remove(fname.c_str());
         const alps::accumulators::result_set& res=acc_gen.results();
         alps::hdf5::archive ar(fname,"w");
@@ -61,7 +61,7 @@ struct AccumulatorTest : public testing::Test {
 
     /// Save and load accumulator set, check results
     void TestSaveLoadAccumulator() {
-        const std::string fname="saveload_acc.h5";
+        const std::string fname="sl_saveload_acc.h5";
         std::remove(fname.c_str());
         const alps::accumulators::accumulator_set& m=acc_gen.accumulators();
         {
@@ -90,7 +90,7 @@ struct AccumulatorTest : public testing::Test {
 
     /// Save and load result set, check results
     void TestSaveLoadResult() {
-        const std::string fname="saveload_res.h5";
+        const std::string fname="sl_saveload_res.h5";
         std::remove(fname.c_str());
         const alps::accumulators::result_set& r=acc_gen.results();
         {

--- a/gf/test/four_index_gf_test.cpp
+++ b/gf/test/four_index_gf_test.cpp
@@ -90,18 +90,18 @@ TEST_F(FourIndexGFTest,saveload)
 {
     namespace g=alps::gf;
     {
-        alps::hdf5::archive oar("gf.h5","w");
+        alps::hdf5::archive oar("gf_4i_saveload.h5","w");
         gf(g::matsubara_index(4),g::momentum_index(3), g::momentum_index(2), g::index(1))=std::complex<double>(7., 3.);
         gf.save(oar,"/gf");
     }
     {
-        alps::hdf5::archive iar("gf.h5");
+        alps::hdf5::archive iar("gf_4i_saveload.h5");
         gf2.load(iar,"/gf");
     }
     EXPECT_EQ(7, gf2(g::matsubara_index(4),g::momentum_index(3), g::momentum_index(2), g::index(1)).real());
     EXPECT_EQ(3, gf2(g::matsubara_index(4),g::momentum_index(3), g::momentum_index(2), g::index(1)).imag());
     {
-        alps::hdf5::archive oar("gf.h5","rw");
+        alps::hdf5::archive oar("gf_4i_saveload.h5","rw");
         oar["/gf/version/major"]<<7;
         EXPECT_THROW(gf2.load(oar,"/gf"),std::runtime_error);
     }
@@ -116,18 +116,18 @@ TEST_F(FourIndexGFTest,saveloadstream)
 {
     namespace g=alps::gf;
     {
-        alps::hdf5::archive oar("gf_stream.h5","w");
+        alps::hdf5::archive oar("gf_4i_stream.h5","w");
         gf(g::matsubara_index(4),g::momentum_index(3), g::momentum_index(2), g::index(1))=std::complex<double>(7., 3.);
         oar["/gf"] << gf;
     }
     {
-        alps::hdf5::archive iar("gf_stream.h5");
+        alps::hdf5::archive iar("gf_4i_stream.h5");
         iar["/gf"] >> gf2;
     }
     EXPECT_EQ(7, gf2(g::matsubara_index(4),g::momentum_index(3), g::momentum_index(2), g::index(1)).real());
     EXPECT_EQ(3, gf2(g::matsubara_index(4),g::momentum_index(3), g::momentum_index(2), g::index(1)).imag());
     {
-        alps::hdf5::archive oar("gf.h5","rw");
+        alps::hdf5::archive oar("gf_4i_stream.h5","rw");
         oar["/gf/version/major"]<<7;
         EXPECT_THROW(oar["/gf"]>>gf2, std::runtime_error);
     }
@@ -217,12 +217,12 @@ TEST_F(FourIndexGFTest, TailSaveLoad)
     EXPECT_EQ(0,gft.max_tail_order());
     EXPECT_EQ(0,(denmat-gft.tail(0)).norm());
     {
-        alps::hdf5::archive oar("gft.h5","w");
+        alps::hdf5::archive oar("gf_4i_tail.h5","w");
         gft(g::matsubara_index(4),g::momentum_index(3), g::momentum_index(2), g::index(1))=std::complex<double>(7., 3.);
         oar["/gft"] << gft;
     }
     {
-        alps::hdf5::archive iar("gft.h5");
+        alps::hdf5::archive iar("gf_4i_tail.h5");
         
         iar["/gft"] >> gft2;
     }
@@ -255,11 +255,11 @@ TEST_F(FourIndexGFTest, DefaultConstructive)
     gf_type gf_empty;
     EXPECT_THROW(gf_empty.norm(), std::runtime_error);
     {
-        alps::hdf5::archive oar("gf.h5","w");
+        alps::hdf5::archive oar("gf_4i_defconstr.h5","w");
         oar["/gf"] << gf;
     }
     {
-        alps::hdf5::archive iar("gf.h5");
+        alps::hdf5::archive iar("gf_4i_defconstr.h5");
         iar["/gf"] >> gf_empty;
     }
     EXPECT_NO_THROW(gf_empty.norm());

--- a/gf/test/itime_gf_test.cpp
+++ b/gf/test/itime_gf_test.cpp
@@ -63,17 +63,17 @@ TEST_F(ItimeTestGF,saveload)
 {
     namespace g=alps::gf;
     {
-        alps::hdf5::archive oar("gf.h5","w");
+        alps::hdf5::archive oar("gf_it_saveload.h5","w");
         gf(g::itime_index(4),g::momentum_index(3), g::momentum_index(2), g::index(1))=6.;
         gf.save(oar,"/gf");
     }
     {
-        alps::hdf5::archive iar("gf.h5");
+        alps::hdf5::archive iar("gf_it_saveload.h5");
         gf2.load(iar,"/gf");
     }
     EXPECT_EQ(6., gf2(g::itime_index(4),g::momentum_index(3), g::momentum_index(2), g::index(1)));
     {
-        alps::hdf5::archive oar("gf.h5","rw");
+        alps::hdf5::archive oar("gf_it_saveload.h5","rw");
         oar["/gf/version/major"]<<7;
         EXPECT_THROW(gf2.load(oar,"/gf"),std::runtime_error);
     }
@@ -87,17 +87,17 @@ TEST_F(ItimeTestGF,saveloadstream)
 {
     namespace g=alps::gf;
     {
-        alps::hdf5::archive oar("gf.h5","w");
+        alps::hdf5::archive oar("gf_it_stream.h5","w");
         gf(g::itime_index(4),g::momentum_index(3), g::momentum_index(2), g::index(1))=6.;
         oar["/gf"] << gf;
     }
     {
-        alps::hdf5::archive iar("gf.h5");
+        alps::hdf5::archive iar("gf_it_stream.h5");
         iar["/gf"] >> gf2;
     }
     EXPECT_EQ(6., gf2(g::itime_index(4),g::momentum_index(3), g::momentum_index(2), g::index(1)));
     {
-        alps::hdf5::archive oar("gf.h5","rw");
+        alps::hdf5::archive oar("gf_it_stream.h5","rw");
         oar["/gf/version/major"]<<7;
         EXPECT_THROW(oar["/gf"]>>gf2, std::runtime_error);
     }

--- a/gf/test/one_index_gf_test.cpp
+++ b/gf/test/one_index_gf_test.cpp
@@ -31,18 +31,18 @@ TEST_F(OneIndexGFTest,saveload)
 {
     namespace g=alps::gf;
     {
-        alps::hdf5::archive oar("gf.h5","w");
+        alps::hdf5::archive oar("gf_1i_saveload.h5","w");
         gf(g::matsubara_index(4))=std::complex<double>(7., 3.);
         gf.save(oar,"/gf");
     }
     {
-        alps::hdf5::archive iar("gf.h5");
+        alps::hdf5::archive iar("gf_1i_saveload.h5");
         gf2.load(iar,"/gf");
     }
     EXPECT_EQ(7, gf2(g::matsubara_index(4)).real());
     EXPECT_EQ(3, gf2(g::matsubara_index(4)).imag());
     {
-        alps::hdf5::archive oar("gf.h5","rw");
+        alps::hdf5::archive oar("gf_1i_saveload.h5","rw");
         oar["/gf/version/major"]<<7;
         EXPECT_THROW(gf2.load(oar,"/gf"),std::runtime_error);
     }
@@ -54,18 +54,18 @@ TEST_F(OneIndexGFTest,saveloadstream)
 {
     namespace g=alps::gf;
     {
-        alps::hdf5::archive oar("gf.h5","w");
+        alps::hdf5::archive oar("gf_1i_saveloadstr.h5","w");
         gf(g::matsubara_index(4))=std::complex<double>(7., 3.);
         oar["/gf"] << gf;
     }
     {
-        alps::hdf5::archive iar("gf.h5");
+        alps::hdf5::archive iar("gf_1i_saveloadstr.h5");
         iar["/gf"] >> gf2;
     }
     EXPECT_EQ(7, gf2(g::matsubara_index(4)).real());
     EXPECT_EQ(3, gf2(g::matsubara_index(4)).imag());
     {
-        alps::hdf5::archive oar("gf.h5","rw");
+        alps::hdf5::archive oar("gf_1i_saveloadstr.h5","rw");
         oar["/gf/version/major"]<<7;
         EXPECT_THROW(oar["/gf"]>>gf2, std::runtime_error);
     }
@@ -165,11 +165,11 @@ TEST_F(OneIndexGFTest, DefaultConstructive)
     gf_type gf_empty;
     EXPECT_THROW(gf_empty.norm(), std::runtime_error);
     {
-        alps::hdf5::archive oar("gf.h5","w");
+        alps::hdf5::archive oar("gf_1i_defconstr.h5","w");
         oar["/gf"] << gf;
     }
     {
-        alps::hdf5::archive iar("gf.h5");
+        alps::hdf5::archive iar("gf_1i_defconstr.h5");
         iar["/gf"] >> gf_empty;
     }
     EXPECT_NO_THROW(gf_empty.norm());

--- a/gf/test/seven_index_gf_test.cpp
+++ b/gf/test/seven_index_gf_test.cpp
@@ -54,18 +54,18 @@ TEST_F(SevenIndexGFTest,saveload)
     namespace g=alps::gf;
     alps::gf::index i1(1),i2(3),i3(4),i4(2),i5(6),i6(0),i7(6);
     {
-        alps::hdf5::archive oar("gf.h5","w");
+        alps::hdf5::archive oar("gf_7i_saveload.h5","w");
         gf(i1,i2,i3,i4,i5,i6,i7)=std::complex<double>(7., 3.);
         gf.save(oar,"/gf");
     }
     {
-        alps::hdf5::archive iar("gf.h5");
+        alps::hdf5::archive iar("gf_7i_saveload.h5");
         gf2.load(iar,"/gf");
     }
     EXPECT_EQ(7, gf2(i1,i2,i3,i4,i5,i6,i7).real());
     EXPECT_EQ(3, gf2(i1,i2,i3,i4,i5,i6,i7).imag());
     {
-        alps::hdf5::archive oar("gf.h5","rw");
+        alps::hdf5::archive oar("gf_7i_saveload.h5","rw");
         oar["/gf/version/major"]<<7;
         EXPECT_THROW(gf2.load(oar,"/gf"),std::runtime_error);
     }
@@ -76,18 +76,18 @@ TEST_F(SevenIndexGFTest,saveloadstream)
     namespace g=alps::gf;
     alps::gf::index i1(1),i2(3),i3(4),i4(2),i5(6),i6(0),i7(6);
     {
-        alps::hdf5::archive oar("gf.h5","w");
+        alps::hdf5::archive oar("gf_7i_stream.h5","w");
         gf(i1,i2,i3,i4,i5,i6,i7)=std::complex<double>(7., 3.);
         oar["/gf"] << gf;
     }
     {
-        alps::hdf5::archive iar("gf.h5");
+        alps::hdf5::archive iar("gf_7i_stream.h5");
         iar["/gf"] >> gf2;
     }
     EXPECT_EQ(7, gf2(i1,i2,i3,i4,i5,i6,i7).real());
     EXPECT_EQ(3, gf2(i1,i2,i3,i4,i5,i6,i7).imag());
     {
-        alps::hdf5::archive oar("gf.h5","rw");
+        alps::hdf5::archive oar("gf_7i_stream.h5","rw");
         oar["/gf/version/major"]<<7;
         EXPECT_THROW(oar["/gf"] >> gf2, std::runtime_error);
     }

--- a/gf/test/three_index_gf_test.cpp
+++ b/gf/test/three_index_gf_test.cpp
@@ -55,18 +55,18 @@ TEST_F(ThreeIndexGFTest,saveload)
 {
     namespace g=alps::gf;
     {
-        alps::hdf5::archive oar("gf.h5","w");
+        alps::hdf5::archive oar("gf_3i_saveload.h5","w");
         gf(g::matsubara_index(4),g::momentum_index(3), g::index(1))=std::complex<double>(7., 3.);
         gf.save(oar,"/gf");
     }
     {
-        alps::hdf5::archive iar("gf.h5");
+        alps::hdf5::archive iar("gf_3i_saveload.h5");
         gf2.load(iar,"/gf");
     }
     EXPECT_EQ(7, gf2(g::matsubara_index(4),g::momentum_index(3), g::index(1)).real());
     EXPECT_EQ(3, gf2(g::matsubara_index(4),g::momentum_index(3), g::index(1)).imag());
     {
-        alps::hdf5::archive oar("gf.h5","rw");
+        alps::hdf5::archive oar("gf_3i_saveload.h5","rw");
         oar["/gf/version/major"]<<7;
         EXPECT_THROW(gf2.load(oar,"/gf"),std::runtime_error);
     }
@@ -78,18 +78,18 @@ TEST_F(ThreeIndexGFTest,saveloadstream)
 {
     namespace g=alps::gf;
     {
-        alps::hdf5::archive oar("gf.h5","w");
+        alps::hdf5::archive oar("gf_3i_saveloadstr.h5","w");
         gf(g::matsubara_index(4),g::momentum_index(3), g::index(1))=std::complex<double>(7., 3.);
         oar["/gf"] << gf;
     }
     {
-        alps::hdf5::archive iar("gf.h5");
+        alps::hdf5::archive iar("gf_3i_saveloadstr.h5");
         iar["/gf"] >> gf2;
     }
     EXPECT_EQ(7, gf2(g::matsubara_index(4),g::momentum_index(3), g::index(1)).real());
     EXPECT_EQ(3, gf2(g::matsubara_index(4),g::momentum_index(3), g::index(1)).imag());
     {
-        alps::hdf5::archive oar("gf.h5","rw");
+        alps::hdf5::archive oar("gf_3i_saveloadstr.h5","rw");
         oar["/gf/version/major"]<<7;
         EXPECT_THROW(oar["/gf"]>>gf2, std::runtime_error);
     }
@@ -170,12 +170,12 @@ TEST_F(ThreeIndexGFTest, TailSaveLoad)
     EXPECT_EQ(0,gft.max_tail_order());
     EXPECT_EQ(0,(denmat-gft.tail(0)).norm());
     {
-        alps::hdf5::archive oar("gft.h5","w");
+        alps::hdf5::archive oar("gf_3i_tail.h5","w");
         gft(g::matsubara_index(4),g::momentum_index(3), g::index(1))=std::complex<double>(7., 3.);
         oar["/gft"] << gft;
     }
     {
-        alps::hdf5::archive iar("gft.h5");
+        alps::hdf5::archive iar("gf_3i_tail.h5");
         iar["/gft"] >> gft2;
     }
     EXPECT_EQ(gft2.tail().size(), gft.tail().size()) << "Tail size mismatch";
@@ -387,11 +387,11 @@ TEST_F(ThreeIndexGFTest, DefaultConstructive)
     gf_type gf_empty;
     EXPECT_THROW(gf_empty.norm(), std::runtime_error);
     {
-        alps::hdf5::archive oar("gf.h5","w");
+        alps::hdf5::archive oar("gf_3i_defconstr.h5","w");
         oar["/gf"] << gf;
     }
     {
-        alps::hdf5::archive iar("gf.h5");
+        alps::hdf5::archive iar("gf_3i_defconstr.h5");
         iar["/gf"] >> gf_empty;
     }
     EXPECT_NO_THROW(gf_empty.norm());

--- a/gf/test/two_index_gf_test.cpp
+++ b/gf/test/two_index_gf_test.cpp
@@ -84,18 +84,18 @@ TEST_F(TwoIndexGFTest,saveload)
 {
     namespace g=alps::gf;
     {
-        alps::hdf5::archive oar("gf.h5","w");
+        alps::hdf5::archive oar("gf_2i_saveload.h5","w");
         gf(g::matsubara_index(4), g::index(1))=std::complex<double>(7., 3.);
         gf.save(oar,"/gf");
     }
     {
-        alps::hdf5::archive iar("gf.h5");
+        alps::hdf5::archive iar("gf_2i_saveload.h5");
         gf2.load(iar,"/gf");
     }
     EXPECT_EQ(7, gf2(g::matsubara_index(4), g::index(1)).real());
     EXPECT_EQ(3, gf2(g::matsubara_index(4), g::index(1)).imag());
     {
-        alps::hdf5::archive oar("gf.h5","rw");
+        alps::hdf5::archive oar("gf_2i_saveload.h5","rw");
         oar["/gf/version/major"]<<7;
         EXPECT_THROW(gf2.load(oar,"/gf"),std::runtime_error);
     }
@@ -107,18 +107,18 @@ TEST_F(TwoIndexGFTest,saveloadstream)
 {
     namespace g=alps::gf;
     {
-        alps::hdf5::archive oar("gf.h5","w");
+        alps::hdf5::archive oar("gf_2i_saveloadstr.h5","w");
         gf(g::matsubara_index(4), g::index(1))=std::complex<double>(7., 3.);
         oar["/gf"] << gf;
     }
     {
-        alps::hdf5::archive iar("gf.h5");
+        alps::hdf5::archive iar("gf_2i_saveloadstr.h5");
         iar["/gf"] >> gf2;
     }
     EXPECT_EQ(7, gf2(g::matsubara_index(4), g::index(1)).real());
     EXPECT_EQ(3, gf2(g::matsubara_index(4), g::index(1)).imag());
     {
-        alps::hdf5::archive oar("gf.h5","rw");
+        alps::hdf5::archive oar("gf_2i_saveloadstr.h5","rw");
         oar["/gf/version/major"]<<7;
         EXPECT_THROW(oar["/gf"]>>gf2, std::runtime_error);
     }
@@ -234,12 +234,12 @@ TEST_F(TwoIndexGFTest, TailSaveLoad)
     EXPECT_EQ(0,gft.max_tail_order());
     EXPECT_EQ(0,(denmat-gft.tail(0)).norm());
     {
-        alps::hdf5::archive oar("gft.h5","w");
+        alps::hdf5::archive oar("gf_2i_tailsaveload.h5","w");
         gft(g::matsubara_index(4),g::index(1))=std::complex<double>(7., 3.);
         oar["/gft"] << gft;
     }
     {
-        alps::hdf5::archive iar("gft.h5");
+        alps::hdf5::archive iar("gf_2i_tailsaveload.h5");
 
         iar["/gft"] >> gft2;
     }
@@ -271,11 +271,11 @@ TEST_F(TwoIndexGFTest, DefaultConstructive)
     gf_type gf_empty;
     EXPECT_THROW(gf_empty.norm(), std::runtime_error);
     {
-        alps::hdf5::archive oar("gf.h5","w");
+        alps::hdf5::archive oar("gf_2i_defconstr.h5","w");
         oar["/gf"] << gf;
     }
     {
-        alps::hdf5::archive iar("gf.h5");
+        alps::hdf5::archive iar("gf_2i_defconstr.h5");
         iar["/gf"] >> gf_empty;
     }
     EXPECT_NO_THROW(gf_empty.norm());

--- a/mc/src/stop_callback.cpp
+++ b/mc/src/stop_callback.cpp
@@ -28,13 +28,13 @@ namespace alps {
         if (comm) {
             bool to_stop;
             if (comm->rank() == 0) {
-                to_stop = !signals.empty() || (limit > 0 && clock_type::time_diff(now, start) > limit);
+                to_stop = !signals.empty() || (limit > 0 && clock_type::time_diff(now, start) >= limit);
             }
             broadcast(*comm, to_stop, 0);
             return to_stop;
         } else
 #endif
-            return !signals.empty() || (limit > 0 && clock_type::time_diff(now, start) > limit);
+            return !signals.empty() || (limit > 0 && clock_type::time_diff(now, start) >= limit);
     }
 
 
@@ -45,6 +45,6 @@ namespace alps {
 
     bool simple_time_callback::operator()() const {
         time_point_type now(clock_type::now_time());
-        return (limit > 0 && clock_type::time_diff(now, start) > limit);
+        return (limit > 0 && clock_type::time_diff(now, start) >= limit);
     }
 }

--- a/mc/test/timer.cpp
+++ b/mc/test/timer.cpp
@@ -19,7 +19,7 @@ template <typename C>
 class TestCallback : public ::testing::Test {
   public:
     typedef C callback_type;
-    static const std::size_t TIMELIMIT=3; 
+    static const std::size_t TIMELIMIT=1;
     alps::params param_;
 
     TestCallback() {}

--- a/mc/test/timer_in_sim.cpp
+++ b/mc/test/timer_in_sim.cpp
@@ -43,7 +43,7 @@ template <typename C>
 class TestCallback : public ::testing::Test {
   public:
     typedef C callback_type;
-    static const std::size_t TIMELIMIT=3; 
+    static const std::size_t TIMELIMIT=1;
     alps::params param_;
     longish_sim sim_;
 


### PR DESCRIPTION
Some GF and accumulator tests request the same HDF5 filename,
which is a problem when running the tests in parallel using
`ctest -jXX`.  This assigns a unique filename to all files in
the test.

Also, it tightens some of the timeouts in the MC class.