### PR TITLE
[params] Fix issue #359

### DIFF
--- a/params/include/alps/params.hpp
+++ b/params/include/alps/params.hpp
@@ -128,7 +128,7 @@ namespace alps {
             /// Constructor from command line and a parameter file. The parsing is deferred.
             /** Tries to see if the file is an HDF5, in which case restores the object from the
                 HDF5 file, ignoring the command line.
-                
+
                 @param hdfpath : path to HDF5 dataset containing the saved parameter object
                 (NULL if this functionality is not needed)
             */
@@ -184,7 +184,7 @@ namespace alps {
 
             /** Returns iterator to beyond-the-end of "missing" parameters */
             missing_params_iterator end_missing() const;
-            
+
 
             /// Check if a parameter exists (that is: attempt to read a compatible-typed value from it will not throw)
             bool exists(const std::string& name) const;
@@ -249,6 +249,18 @@ namespace alps {
 
             /// Stream parameters
             friend std::ostream& operator<<(std::ostream& str, params const& x);
+
+            /// Pick parameter by name and apply a generic functor f to it.
+            /// For any allowed parameter type T, f must be callable as
+            /// f(const std::string& name, boost::optional<T> const& val, boost::optional<T> const& defval, const std::string& descr)
+            template <typename F>
+            friend void apply(const params& opts, const std::string& optname, F const& f);
+
+            /// Apply a generic functor f to each defined parameter
+            /// For any allowed parameter type T, f must be callable as
+            /// f(const std::string& name, boost::optional<T> const& val, boost::optional<T> const& defval, const std::string& descr)
+            template <typename F>
+            friend void foreach(const params& opts, F const& f);
         };
 
         // FIXME: we may consider provide template specializations for specific types? To hide templates inside *.cpp?

--- a/params/include/alps/params/option_description_type.hpp
+++ b/params/include/alps/params/option_description_type.hpp
@@ -9,15 +9,40 @@
 
 namespace alps {
     namespace params_ns {
+
+        template <typename> struct params_apply_visitor;
+
         namespace detail {
 
             /// Option (parameter) description class. Used to interface with boost::program_options
             class option_description_type {
               private:
                 typedef boost::program_options::options_description po_descr;
-                
+
+                template <typename> friend struct alps::params_ns::params_apply_visitor;
+
                 std::string descr_; ///< Parameter description
                 variant_all_type deflt_; ///< To keep type and defaults(if any)
+
+                /// Visitor class to check for option being a trigger
+                struct is_trigger_visitor : public boost::static_visitor<bool>
+                {
+                    bool operator()(const None&) const
+                    {
+                        throw std::logic_error("is_trigger_visitor is called for an object containing None: should not happen!");
+                    }
+
+                    bool operator()(const boost::optional<trigger_tag>&) const
+                    {
+                        return true;
+                    }
+
+                    template <typename T>
+                    bool operator()(const boost::optional<T>&) const
+                    {
+                        return false;
+                    }
+                };
 
                 /// Visitor class to add the stored description to boost::program_options
                 struct add_option_visitor: public boost::static_visitor<> {
@@ -32,7 +57,7 @@ namespace alps {
                     {
                         throw std::logic_error("add_option_visitor is called for an object containing None: should not happen!");
                     }
-                    
+
                     /// Called by apply_visitor(), for a optional<T> bound type
                     template <typename T>
                     void operator()(const boost::optional<T>& a_val) const
@@ -52,7 +77,7 @@ namespace alps {
                         do_define<trigger_tag>::add_option(odesc_, name_, strdesc_);
                     }
                 };
-                    
+
 
                 /// Visitor class to set option_type instance from boost::any; visitor is used ONLY to extract type information
                 struct set_option_visitor: public boost::static_visitor<> {
@@ -67,7 +92,7 @@ namespace alps {
                     {
                         throw std::logic_error("set_option_visitor is called for an object containing None: should not happen!");
                     }
-                    
+
                     /// Called by apply_visitor(), for a optional<T> bound type
                     template <typename T>
                     void operator()(const boost::optional<T>& a_val) const
@@ -125,7 +150,7 @@ namespace alps {
                         } else {
                             ar_[name_] << T();
                             ar_[name_+"@has_default"] << false;
-                        } 
+                        }
                         ar_[name_+"@is_trigger"] << false;
                    }
 
@@ -164,7 +189,7 @@ namespace alps {
                           is_trigger_(false),
                           has_default_(false)
                     {
-                        const std::string trigger_attr=path+"@is_trigger";  
+                        const std::string trigger_attr=path+"@is_trigger";
                         const std::string deflt_attr=path+"@has_default";
                         const std::string descr_attr=path+"@description";
 
@@ -258,11 +283,11 @@ namespace alps {
 
                 /// Constructor for description with default
                 template <typename T>
-                option_description_type(const std::string& a_descr, T a_deflt): descr_(a_descr), deflt_(boost::optional<T>(a_deflt)) 
+                option_description_type(const std::string& a_descr, T a_deflt): descr_(a_descr), deflt_(boost::optional<T>(a_deflt))
                 { }
 
                 /// Constructor for a trigger option
-                option_description_type(const std::string& a_descr): descr_(a_descr), deflt_(boost::optional<trigger_tag>(trigger_tag())) 
+                option_description_type(const std::string& a_descr): descr_(a_descr), deflt_(boost::optional<trigger_tag>(trigger_tag()))
                 { }
 
                 /// Factory method for loading from archive
@@ -270,7 +295,7 @@ namespace alps {
                 static option_description_type get_loaded(alps::hdf5::archive& ar, const std::string& key)
                 {
                     reader rd(ar,key);
-                    
+
                     // macro: try reading, return if ok
 #define ALPS_LOCAL_TRY_LOAD(_r_,_d_,_type_)                           \
                     if (rd.can_read((_type_*)0)) return rd.read((_type_*)0);
@@ -278,10 +303,16 @@ namespace alps {
                     // try reading for each defined type
                      BOOST_PP_SEQ_FOR_EACH(ALPS_LOCAL_TRY_LOAD, X, ALPS_PARAMS_DETAIL_ALLTYPES_SEQ);
 #undef ALPS_LOCAL_TRY_LOAD
-                    
+
                     throw std::runtime_error("No matching payload type in the archive "
                                              "for `option_description_type` for "
                                              "path='" + key + "'");
+                }
+
+                /// Is this option a trigger?
+                bool is_trigger() const
+                {
+                    return boost::apply_visitor(is_trigger_visitor(), deflt_);
                 }
 
                 /// Adds to program_options options_description
@@ -294,7 +325,7 @@ namespace alps {
                 void set_option(option_type& opt, const boost::any& a_val) const
                 {
                     boost::apply_visitor(set_option_visitor(opt, a_val), deflt_);
-                }                
+                }
 
                 // Note the signature is different from a regular save()
                 void save(hdf5::archive& ar, const std::string& name) const
@@ -307,7 +338,7 @@ namespace alps {
                 /// Default ctor for internal use (in factory methods)
                 // FIXME: had to make it public for map broadcast
                 option_description_type() {}
-                
+
 #ifdef ALPS_HAVE_MPI
                 // FIXME: copy&paste from option_type. Generalize and factor out!
                 void broadcast(const alps::mpi::communicator& comm, int root)
@@ -334,15 +365,15 @@ namespace alps {
                                     deflt_=buf;                         \
                                 }                                       \
                             } /* end macro */
-                        
+
                             BOOST_PP_SEQ_FOR_EACH(ALPS_LOCAL_TRY_TYPE, X, ALPS_PARAMS_DETAIL_ALLTYPES_SEQ);
 #undef ALPS_LOCAL_TRY_TYPE
                             assert(deflt_.which()==root_which && "The `which` value must be the same as on root");
-                        } // done with slave rank 
+                        } // done with slave rank
                     }
                 }
 #endif
-                
+
             };
 
             typedef std::map<std::string, option_description_type> description_map_type;
@@ -360,7 +391,7 @@ namespace alps {
     }
 #endif
 
-    
+
 } // alps::
 
 #endif /* ALPS_PARAMS_OPTION_DESCRIPTION_TYPE_27836b27fafb4e60a89a59b80016bebc */

--- a/params/include/alps/params/param_types.hpp
+++ b/params/include/alps/params/param_types.hpp
@@ -35,7 +35,7 @@
 namespace alps {
     namespace params_ns {
         namespace detail {
-            
+
 	    // Allowed basic numerical types.
 	    // NOTE 1: do not forget to change "8" to the correct number if editing!
 	    // NOTE 2: currently, not more than (20-1)/2 = 9 types are supported
@@ -82,7 +82,7 @@ namespace alps {
             {
                 throw std::logic_error("Attempt to use undefined operator<< for trigger_tag");
             }
-          
+
              // Sequence of trigger type, scalar and vector types
 #define     ALPS_PARAMS_DETAIL_ALLTYPES_SEQ ALPS_PARAMS_DETAIL_STYPES_SEQ(trigger_tag)ALPS_PARAMS_DETAIL_VTYPES_SEQ
 
@@ -95,7 +95,7 @@ namespace alps {
             ALPS_PARAMS_DETAIL_TYPID_NAME(const char *);
             // ALPS_PARAMS_DETAIL_TYPID_NAME(unsigned int);
             // ALPS_PARAMS_DETAIL_TYPID_NAME(unsigned long);
-          
+
             // Sequence of `boost::optional<T>` types for all supported types
 #define     ALPS_PARAMS_DETAIL_OTYPES_SEQ BOOST_PP_SEQ_TRANSFORM(ALPS_PARAMS_DETAIL_MAKE_TYPE, boost::optional, ALPS_PARAMS_DETAIL_ALLTYPES_SEQ)
 
@@ -124,7 +124,7 @@ namespace alps {
 // #undef  ALPS_PARAMS_DETAIL_ALLTYPES_SEQ
 // #undef  ALPS_PARAMS_DETAIL_GEN_TYPID
 // #undef  ALPS_PARAMS_DETAIL_OTYPES_SEQ
-	
+
     } // params_ns
 }// alps
 

--- a/params/include/alps/params/params_impl.hpp
+++ b/params/include/alps/params/params_impl.hpp
@@ -202,6 +202,70 @@ namespace alps {
             return *this;
         }
 
+        /// Used in apply() and foreach()
+        template <typename F>
+        struct params_apply_visitor : public boost::static_visitor<>
+        {
+            const std::string& name_;
+            const detail::option_description_type& opt_descr_;
+            const F& f_;
+
+            params_apply_visitor(const std::string& name, const detail::option_description_type& opt_descr, const F& f) :
+                name_(name), opt_descr_(opt_descr), f_(f) {}
+
+            /// Applying to a None type --- always fails
+            void operator()(const detail::None&) const
+            {
+                throw option_type::visitor_none_used("Attempt to use uninitialized option value");
+            }
+
+            /// Triggers are to be treated specially, because T == bool for them,
+            /// but opt_descr_.deflt_ contains boost::optional<trigger_tag>
+
+            /// Called by apply_visitor()
+            void operator()(const boost::optional<bool>& val) const
+            {
+                if(opt_descr_.is_trigger())
+                    f_(name_, val, boost::optional<bool>(boost::none), opt_descr_.descr_);
+                else
+                    f_(name_, val, boost::get<boost::optional<bool> >(opt_descr_.deflt_), opt_descr_.descr_);
+            }
+
+            /// Called by apply_visitor()
+            template <typename T>
+            void operator()(const boost::optional<T>& val) const
+            {
+                f_(name_, val, boost::get<boost::optional<T> >(opt_descr_.deflt_), opt_descr_.descr_);
+            }
+        };
+
+        template <typename F>
+        inline void apply(const params& opts, const std::string& optname, F const& f)
+        {
+            opts.possibly_parse();
+
+            // opts.optmap_ is mutable, so we have to use const_cast to make compiler choose the right overload of operator[]
+            const options_map_type::mapped_type& o = const_cast<options_map_type const&>(opts.optmap_)[optname];
+            // There is no const operator[] in description_map_type
+            detail::description_map_type::const_iterator d_it = opts.descr_map_.find(optname);
+
+            params_apply_visitor<F> v(optname, d_it->second, f);
+            boost::apply_visitor(v, o.val_);
+        }
+
+        template <typename F>
+        inline void foreach(const params& opts, F const& f)
+        {
+            opts.possibly_parse();
+
+            for(options_map_type::const_iterator o_it = opts.optmap_.begin(); o_it != opts.optmap_.end(); o_it++)
+            {
+                detail::description_map_type::const_iterator d_it = opts.descr_map_.find(o_it->first);
+                params_apply_visitor<F> v(o_it->first, d_it->second, f);
+                boost::apply_visitor(v, o_it->second.val_);
+            }
+        }
+
     } // params_ns::
 } // alps::
 

--- a/params/test/CMakeLists.txt
+++ b/params/test/CMakeLists.txt
@@ -16,6 +16,7 @@ set (test_src
      param_ostream
      common_param_tests
      disappearing_ini
+     apply
     )
 
 

--- a/params/test/apply.cpp
+++ b/params/test/apply.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 1998-2017 ALPS Collaboration. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ * For use in publications, see ACKNOWLEDGE.TXT
+ */
+
+/** @file apply.cpp
+
+    @brief Tests the behaviour of apply() and foreach() free functions
+*/
+
+#include <alps/params.hpp>
+
+#include <gtest/gtest.h>
+
+struct ParamTest : public ::testing::Test {
+    alps::params params_;
+
+    ParamTest() {
+        params_.define<int>("integer", 42, "Very important integer");
+        params_.define<double>("pi", "Something from geometry");
+        params_.define<bool>("switch", true, "Has no meaning too");
+        params_.define<std::string>("name", "qwerty", "Name of the game");
+
+        params_["pi"] = 22.0 / 7;
+        params_["name"] = "asdfgh";
+    }
+};
+
+template <typename ExpectedType>
+struct apply_test_functor {
+
+    /// Expected option properties
+    std::string name_;
+    bool has_val_;
+    ExpectedType val_;
+    bool has_deflt_;
+    ExpectedType deflt_;
+    std::string descr_;
+
+    apply_test_functor(const std::string& name,
+                       bool has_val, const ExpectedType& val,
+                       bool has_deflt, const ExpectedType& deflt,
+                       const std::string& descr) :
+        name_(name), has_val_(has_val), val_(val), has_deflt_(has_deflt), deflt_(deflt), descr_(descr) {}
+
+    /// This overload is called if option has the ExpectedType
+    void operator()(const std::string& name,
+                    boost::optional<ExpectedType> const& val,
+                    boost::optional<ExpectedType> const& defval,
+                    const std::string& descr) const {
+        EXPECT_EQ(name_, name);
+        EXPECT_EQ(has_val_, static_cast<bool>(val));
+        if(static_cast<bool>(val)) EXPECT_EQ(val_, val.value());
+        EXPECT_EQ(has_deflt_, static_cast<bool>(defval));
+        if(static_cast<bool>(defval)) EXPECT_EQ(deflt_, defval.value());
+        EXPECT_EQ(descr_, descr);
+    }
+
+    /// Unexpected option type
+    template <typename T>
+    void operator()(const std::string& name,
+                    boost::optional<T> const& val,
+                    boost::optional<T> const& defval,
+                    const std::string& descr) const {
+        FAIL();
+    }
+};
+
+TEST_F(ParamTest,apply) {
+    apply_test_functor<int> f1("integer", true, 42, true, 42, "Very important integer");
+    apply(params_, "integer", f1);
+
+    apply_test_functor<double> f2("pi", true, 22.0 / 7, false, 0, "Something from geometry");
+    apply(params_, "pi", f2);
+
+    apply_test_functor<bool> f3("switch", true, true, true, true, "Has no meaning too");
+    apply(params_, "switch", f3);
+
+    apply_test_functor<std::string> f4("name", true, "asdfgh", true, "qwerty", "Name of the game");
+    apply(params_, "name", f4);
+}
+
+struct foreach_test_functor {
+
+#define CALL_OPERATOR(TYPE,NAME,HAS_VAL,VAL,HAS_DEFLT,DEFLT,DESCR)                        \
+    void operator()(const std::string& name, boost::optional<TYPE> const& val,            \
+                    boost::optional<TYPE> const& defval, const std::string& descr) const  \
+    {                                                                                     \
+        if(name == "help") return;                                                        \
+        EXPECT_EQ(NAME, name);                                                            \
+        EXPECT_TRUE(HAS_VAL == static_cast<bool>(val));                                   \
+        if(static_cast<bool>(val)) EXPECT_EQ(VAL, val.value());                           \
+        EXPECT_TRUE(HAS_DEFLT == static_cast<bool>(defval));                              \
+        if(static_cast<bool>(defval)) EXPECT_EQ(DEFLT, defval.value());                   \
+        EXPECT_EQ(DESCR, descr);                                                          \
+    }
+
+    CALL_OPERATOR(int, "integer", true, 42, true, 42, "Very important integer")
+    CALL_OPERATOR(double, "pi", true, (22.0/7), false, 0, "Something from geometry")
+    CALL_OPERATOR(bool, "switch", true, true, true, true, "Has no meaning too")
+    CALL_OPERATOR(std::string, "name", true, "asdfgh", true, "qwerty", "Name of the game")
+#undef CALL_OPERATOR
+
+    /// Unexpected option type
+    template <typename T>
+    void operator()(const std::string& name, boost::optional<T> const& val, \
+                    boost::optional<T> const& defval, const std::string& descr) const {
+        FAIL();
+    }
+};
+
+TEST_F(ParamTest,foreach) {
+    foreach(params_, foreach_test_functor());
+}


### PR DESCRIPTION
* Added two free functions, `apply()` and `foreach()`.
```c++
    /// Pick parameter by name and apply a generic functor f to it.
    template <typename F> void apply(const params& opts, const std::string& optname, F const& f);

    /// Apply a generic functor f to each defined parameter
    template <typename F> void foreach(const params& opts, F const& f);
```
For any allowed parameter type `T`, `f` must be callable as
    `f(const std::string& name, boost::optional<T> const& val, boost::optional<T> const& defval, const std::string& descr)`

* Added new method option_description_type::is_trigger().
* Added a unit-test for the new functions.

This interface does not depend on Boost.Program_options, it only requires `boost::optional`, which is in the header-only part. Implementation involves some visitation magic, just as the rest of the `params` class.

From purist's point of view, `apply()` is a bit flawed as it chains together two unrelated actions, looking up a parameter and applying a functor to it. Too bad, I cannot see a way to fix this with the present architecture of the class.

On a side note, I think it is a pretty lame idea to store `option_type` and `option_description_type` objects in two different containers. I guess this issue is already being addressed by @galexv on the other branch.