### PR TITLE
[params] Correction to 92e92ea2b9a6807487d014c6f2bd107d49da50c6

### DIFF
--- a/params/include/alps/params/params_impl.hpp
+++ b/params/include/alps/params/params_impl.hpp
@@ -222,7 +222,7 @@ namespace alps {
             /// Even though this overload must be defined, it should never be called
             void operator()(const boost::optional<detail::trigger_tag>& val) const
             {
-              assert(false);
+                throw std::runtime_error("Internal error");
             }
 
             /// Triggers are to be treated specially, because T == bool for them,

--- a/params/include/alps/params/params_impl.hpp
+++ b/params/include/alps/params/params_impl.hpp
@@ -219,6 +219,12 @@ namespace alps {
                 throw option_type::visitor_none_used("Attempt to use uninitialized option value");
             }
 
+            /// Even though this overload must be defined, it should never be called
+            void operator()(const boost::optional<detail::trigger_tag>& val) const
+            {
+              assert(false);
+            }
+
             /// Triggers are to be treated specially, because T == bool for them,
             /// but opt_descr_.deflt_ contains boost::optional<trigger_tag>
 


### PR DESCRIPTION
`params_apply_visitor` should contain specialization of the call operator for `detail::trigger_tag`. Otherwise, user-provided functor `f` will be instantiated for this type (implementation detail leak).