### PR TITLE
Some function marked as const

### DIFF
--- a/params/include/alps/params.hpp
+++ b/params/include/alps/params.hpp
@@ -155,7 +155,7 @@ namespace alps {
 
             /// Check whether a parameter was ever defined
             // FIXME: we don't really need it, must be removed from client code
-            bool defined(const std::string& name) ALPS_DEPRECATED { return td_map_.count(name)!=0 || exists(name); }
+            bool defined(const std::string& name) const ALPS_DEPRECATED { return td_map_.count(name)!=0 || exists(name); }
 
             /// Defines a parameter; returns false on error, and records the error in the object
             template<typename T>


### PR DESCRIPTION
The CT-HYB code still uses "bool defined()", which should be "const".