### PR TITLE
Fixes most `-Wall` warnings

### DIFF
--- a/accumulators/include/alps/accumulators/accumulator.hpp
+++ b/accumulators/include/alps/accumulators/accumulator.hpp
@@ -130,7 +130,7 @@ namespace alps {
             // get
             private:
                 template<typename T> struct get_visitor: public boost::static_visitor<> {
-                    template<typename X> void operator()(X const & arg) {
+                    template<typename X> void operator()(X const & /*arg*/) {
                         throw std::runtime_error(std::string("Canot cast observable") + typeid(X).name() + " to base type: " + typeid(T).name() + ALPS_STACKTRACE);
                     }
                     void operator()(typename detail::add_base_wrapper_pointer<T>::type const & arg) { value = arg; }
@@ -218,7 +218,7 @@ namespace alps {
                         }                                                                                           \
                         template<typename X> T apply(typename boost::disable_if<                                    \
                             typename detail::is_valid_argument<typename TYPE <X>::type, T>::type, X const &         \
-                        >::type arg) const {                                                                        \
+                        >::type /*arg*/) const {                                                                        \
                             throw std::logic_error(std::string("cannot convert: ")                                  \
                                 + typeid(typename TYPE <X>::type).name() + " to "                                   \
                                 + typeid(T).name() + ALPS_STACKTRACE);                                              \
@@ -285,7 +285,7 @@ namespace alps {
                     }
                     template<typename X> void apply(typename boost::disable_if<
                         typename detail::is_valid_argument<T, typename value_type<X>::type>::type, X &
-                    >::type arg) const {
+                    >::type /*arg*/) const {
                         throw std::logic_error(std::string("cannot convert: ") + typeid(T).name() + " to " + typeid(typename value_type<X>::type).name() + ALPS_STACKTRACE);
                     }
                     template<typename X> void operator()(X & arg) const {
@@ -603,7 +603,7 @@ namespace alps {
                     }
                     template<typename X> void apply(typename boost::disable_if<
                         typename detail::is_valid_argument<T, typename value_type<X>::type>::type, X &
-                    >::type arg) const {
+                    >::type /*arg*/) const {
                         throw std::logic_error(std::string("cannot convert: ") + typeid(T).name() + " to " + typeid(typename value_type<X>::type).name() + ALPS_STACKTRACE);
                     }
                     template<typename X> void operator()(X & arg) const {
@@ -729,7 +729,7 @@ namespace alps {
             // get
             private:
                 template<typename T> struct get_visitor: public boost::static_visitor<> {
-                    template<typename X> void operator()(X const & arg) {
+                    template<typename X> void operator()(X const & /*arg*/) {
                         throw std::runtime_error(std::string("Canot cast observable") + typeid(X).name() + " to base type: " + typeid(T).name() + ALPS_STACKTRACE);
                     }
                     void operator()(typename detail::add_base_wrapper_pointer<T>::type const & arg) { value = arg; }
@@ -776,7 +776,7 @@ namespace alps {
                         }                                                                                           \
                         template<typename X> T apply(typename boost::disable_if<                                    \
                             typename detail::is_valid_argument<typename TYPE <X>::type, T>::type, X const &         \
-                        >::type arg) const {                                                                        \
+                        >::type /*arg*/) const {                                                                        \
                             throw std::logic_error(std::string("cannot convert: ")                                  \
                                 + typeid(typename TYPE <X>::type).name() + " to "                                   \
                                 + typeid(T).name() + ALPS_STACKTRACE);                                              \

--- a/accumulators/include/alps/accumulators/feature.hpp
+++ b/accumulators/include/alps/accumulators/feature.hpp
@@ -84,14 +84,14 @@ namespace alps {
 
                 /// Dummy function for merging results (always throws an exception)
                 template <typename A>
-                void merge(const A& rhs) {
+                void merge(const A& /*rhs*/) {
                      throw std::runtime_error("A result cannot be merged " + ALPS_STACKTRACE);
                 }
               
 #ifdef ALPS_HAVE_MPI
                 inline void collective_merge(
-                      alps::mpi::communicator const & comm
-                    , int root
+                      alps::mpi::communicator const & /*comm*/
+                    , int /*root*/
                 ) const {
                     throw std::logic_error("A result cannot be merged " + ALPS_STACKTRACE);
                 }

--- a/accumulators/include/alps/accumulators/feature/binning_analysis.hpp
+++ b/accumulators/include/alps/accumulators/feature/binning_analysis.hpp
@@ -255,7 +255,7 @@ namespace alps {
                         using alps::numeric::check_size;
 
                         B::operator()(val);
-                        if(static_cast<size_t>(B::count()) == (1UL << m_ac_sum2.size())) {
+                        if(B::count() == (1UL << m_ac_sum2.size())) {
                             m_ac_sum2.push_back(T());
                             check_size(m_ac_sum2.back(), val);
                             m_ac_sum.push_back(T());

--- a/accumulators/include/alps/accumulators/feature/binning_analysis.hpp
+++ b/accumulators/include/alps/accumulators/feature/binning_analysis.hpp
@@ -255,7 +255,7 @@ namespace alps {
                         using alps::numeric::check_size;
 
                         B::operator()(val);
-                        if(B::count() == (1 << m_ac_sum2.size())) {
+                        if(static_cast<size_t>(B::count()) == (1UL << m_ac_sum2.size())) {
                             m_ac_sum2.push_back(T());
                             check_size(m_ac_sum2.back(), val);
                             m_ac_sum.push_back(T());

--- a/accumulators/include/alps/accumulators/feature/binning_analysis.hpp
+++ b/accumulators/include/alps/accumulators/feature/binning_analysis.hpp
@@ -101,7 +101,7 @@ namespace alps {
             template<typename A> typename boost::disable_if<
                   typename has_feature<A, binning_analysis_tag>::type
                 , typename autocorrelation_type<A>::type
-            >::type autocorrelation_impl(A const & acc) {
+            >::type autocorrelation_impl(A const & /*acc*/) {
                 throw std::runtime_error(std::string(typeid(A).name()) + " has no autocorrelation-method" + ALPS_STACKTRACE);
                 return *static_cast<typename autocorrelation_type<A>::type *>(NULL);
             }
@@ -688,7 +688,7 @@ namespace alps {
                         for (error_iterator it = m_ac_errors.begin(); it != m_ac_errors.end(); ++it)
                             *it = *it + dynamic_cast<scalar_result_type const &>(arg).error(it - m_ac_errors.begin());
                     }
-                    template<typename U> void augaddsub (U const & arg, typename boost::enable_if<boost::is_scalar<U>, int>::type = 0) {}
+                    template<typename U> void augaddsub (U const & /*arg*/, typename boost::enable_if<boost::is_scalar<U>, int>::type = 0) {}
 
                     template<typename U> void augmul (U const & arg, typename boost::enable_if<is_rel_type<U>, int>::type = 0) {
                         using alps::numeric::operator*;

--- a/accumulators/include/alps/accumulators/feature/count.hpp
+++ b/accumulators/include/alps/accumulators/feature/count.hpp
@@ -87,7 +87,7 @@ namespace alps {
                         throw std::runtime_error("No values can be added to a result" + ALPS_STACKTRACE);
                     }
 
-                    template<typename S> void print(S & os, bool terse=false) const {
+                    template<typename S> void print(S & os, bool /*terse*/=false) const {
                         os << " #" << alps::short_print(count());
                     }
 
@@ -186,7 +186,7 @@ namespace alps {
 
                     Accumulator(Accumulator const & arg): m_count(arg.m_count) {}
 
-                    template<typename ArgumentPack> Accumulator(ArgumentPack const & args, typename boost::disable_if<is_accumulator<ArgumentPack>, int>::type = 0)
+                    template<typename ArgumentPack> Accumulator(ArgumentPack const & /*args*/, typename boost::disable_if<is_accumulator<ArgumentPack>, int>::type = 0)
                         : m_count(count_type())
                     {}
 
@@ -201,7 +201,7 @@ namespace alps {
                         throw std::runtime_error("Observable has no binary call operator" + ALPS_STACKTRACE);
                     }
 
-                    template<typename S> void print(S & os, bool terse=false) const {
+                    template<typename S> void print(S & os, bool /*terse*/=false) const {
                         os << " #" << alps::short_print(count());
                     }
 

--- a/accumulators/include/alps/accumulators/feature/error.hpp
+++ b/accumulators/include/alps/accumulators/feature/error.hpp
@@ -62,7 +62,7 @@ namespace alps {
             template<typename A> typename boost::disable_if<
                   typename has_feature<A, error_tag>::type
                 , typename error_type<A>::type
-            >::type error_impl(A const & acc) {
+            >::type error_impl(A const & /*acc*/) {
                 throw std::runtime_error(std::string(typeid(A).name()) + " has no error-method" + ALPS_STACKTRACE);
                 return typename error_type<A>::type();
             }
@@ -316,7 +316,7 @@ namespace alps {
                         using alps::numeric::operator+;
                         m_error = m_error + arg.error();
                     }
-                    template<typename U> void augaddsub (U const & arg, typename boost::enable_if<boost::is_scalar<U>, int>::type = 0) {}
+                    template<typename U> void augaddsub (U const & /*arg*/, typename boost::enable_if<boost::is_scalar<U>, int>::type = 0) {}
 
                     template<typename U> void augmul (U const & arg, typename boost::disable_if<boost::is_scalar<U>, int>::type = 0) {
                         using alps::numeric::operator*;

--- a/accumulators/include/alps/accumulators/feature/max_num_binning.hpp
+++ b/accumulators/include/alps/accumulators/feature/max_num_binning.hpp
@@ -122,7 +122,7 @@ namespace alps {
             template<typename A> typename boost::disable_if<
                   typename has_feature<A, max_num_binning_tag>::type
                 , typename max_num_binning_type<A>::type
-            >::type max_num_binning_impl(A const & acc) {
+            >::type max_num_binning_impl(A const & /*acc*/) {
                 throw std::runtime_error(std::string(typeid(A).name()) + " has no max_num_binning-method" + ALPS_STACKTRACE);
                 return *static_cast<typename max_num_binning_type<A>::type *>(NULL);
             }
@@ -135,8 +135,8 @@ namespace alps {
                 acc.transform(op);
             }
             template<typename A, typename OP> void transform_impl(
-                  A & acc
-                , OP op
+                  A & /*acc*/
+                , OP /*op*/
                 , typename boost::disable_if<typename has_feature<A, max_num_binning_tag>::type, int>::type = 0
             ) {
                 throw std::runtime_error(std::string(typeid(A).name()) + " has no transform-method" + ALPS_STACKTRACE);
@@ -345,7 +345,7 @@ namespace alps {
                 void partition_bins(alps::mpi::communicator const & comm,
                                     std::vector<typename mean_type<B>::type> & local_bins,
                                     std::vector<typename mean_type<B>::type> & merged_bins,
-                                    int root) const
+                                    int /*root*/) const
                 {
                     using alps::numeric::operator+;
                     using alps::numeric::operator/;

--- a/accumulators/include/alps/accumulators/feature/max_num_binning.hpp
+++ b/accumulators/include/alps/accumulators/feature/max_num_binning.hpp
@@ -74,7 +74,7 @@ namespace alps {
                         return os;
                     }
                     os << m_num_elements << " elements per bin, bins are:\n";
-                    for (int i=0; i<m_bins.size(); ++i) {
+                    for (size_t i=0; i<m_bins.size(); ++i) {
                         os << "#" << (i+1) << ": " << alps::short_print(m_bins[i],4) << "\n";
                     }
                     return os;

--- a/accumulators/include/alps/accumulators/feature/weight.hpp
+++ b/accumulators/include/alps/accumulators/feature/weight.hpp
@@ -65,7 +65,7 @@ namespace alps {
             template<typename A> typename boost::disable_if<
                   typename has_feature<A, weight_tag>::type
                 , base_wrapper<typename value_type<A>::type> const *
-            >::type weight_impl(A const & acc) {
+            >::type weight_impl(A const &) {
                 throw std::runtime_error(std::string(typeid(A).name()) + " has no weight-method" + ALPS_STACKTRACE);
                 return NULL;
             }

--- a/accumulators/include/alps/accumulators/feature/weight_holder.hpp
+++ b/accumulators/include/alps/accumulators/feature/weight_holder.hpp
@@ -69,7 +69,7 @@ namespace alps {
                           typename boost::is_scalar<typename value_type<weight_type>::type>::type
                         , typename boost::is_convertible<X, typename value_type<weight_type>::type>::type
                         , typename boost::is_same<X, typename value_type<weight_type>::type>::type
-                    >::type>::type operator()(T const & val, X const & weight) {
+                    >::type>::type operator()(T const & /*val*/, X const & /*weight*/) {
                         throw std::runtime_error("Invalid type for binary call operator" + ALPS_STACKTRACE);
                     }
 
@@ -107,7 +107,7 @@ namespace alps {
 
                    /// Merge placeholder \remark FIXME: always throws
                     template <typename A>
-                    void merge(const A& rhs)
+                    void merge(const A& /*rhs*/)
                     {
                       throw std::logic_error("Merging weight_holder accumulators is not yet implemented"
                                              +ALPS_STACKTRACE);

--- a/accumulators/include/alps/accumulators/mpi.hpp
+++ b/accumulators/include/alps/accumulators/mpi.hpp
@@ -141,7 +141,7 @@
                     return offset;
                 }
 
-                template<typename T, typename Op, typename C> void reduce_impl(const alps::mpi::communicator & comm, T const & in_values, Op op, int root, boost::true_type, C) {
+                template<typename T, typename Op, typename C> void reduce_impl(const alps::mpi::communicator & comm, T const & in_values, Op /*op*/, int root, boost::true_type, C) {
                     // using alps::mpi::reduce;
                     // reduce(comm, in_values, op, root);
                     using alps::mpi::get_mpi_datatype;                    
@@ -153,7 +153,7 @@
                     
                 }
 
-                template<typename T, typename Op> void reduce_impl(const alps::mpi::communicator & comm, T const & in_values, Op op, int root, boost::false_type, boost::true_type) {
+                template<typename T, typename Op> void reduce_impl(const alps::mpi::communicator & comm, T const & in_values, Op /*op*/, int root, boost::false_type, boost::true_type) {
                     typedef typename alps::hdf5::scalar_type<T>::type scalar_type;
                     using alps::hdf5::get_extent;
                     std::vector<std::size_t> extent(get_extent(in_values));
@@ -168,7 +168,7 @@
                                        get_mpi_datatype(scalar_type()), alps::mpi::is_mpi_op<Op, scalar_type>::op(), root, comm);
                 }
 
-                template<typename T, typename Op, typename C> void reduce_impl(const alps::mpi::communicator & comm, T const & in_values, T & out_values, Op op, int root, boost::true_type, C) {
+                template<typename T, typename Op, typename C> void reduce_impl(const alps::mpi::communicator & comm, T const & in_values, T & out_values, Op /*op*/, int root, boost::true_type, C) {
                     using alps::mpi::reduce;
                     // using boost::mpi::reduce;
                     // reduce(comm, (T)in_values, out_values, op, root); // TODO: WTF? - why does boost not define unsigned long long as native datatype
@@ -186,7 +186,7 @@
                                        alps::mpi::is_mpi_op<Op, T>::op(), root, comm);
                 }
 
-                template<typename T, typename Op> void reduce_impl(const alps::mpi::communicator & comm, T const & in_values, T & out_values, Op op, int root, boost::false_type, boost::true_type) {
+                template<typename T, typename Op> void reduce_impl(const alps::mpi::communicator & comm, T const & in_values, T & out_values, Op /*op*/, int root, boost::false_type, boost::true_type) {
                     typedef typename alps::hdf5::scalar_type<T>::type scalar_type;
                     using alps::hdf5::get_extent;
                     std::vector<std::size_t> extent(get_extent(in_values));
@@ -203,7 +203,7 @@
                                get_mpi_datatype(scalar_type()), alps::mpi::is_mpi_op<Op, scalar_type>::op(), root, comm);
                 }
 
-                template<typename T, typename Op> void reduce_impl(const alps::mpi::communicator & comm, T const & in_values, Op op, int root, boost::false_type, boost::false_type) {
+                template<typename T, typename Op> void reduce_impl(const alps::mpi::communicator & comm, T const & in_values, Op /*op*/, int root, boost::false_type, boost::false_type) {
                     using alps::hdf5::is_vectorizable;
                     if (is_vectorizable(in_values)) {
                         using alps::hdf5::get_extent;
@@ -224,7 +224,7 @@
                         throw std::logic_error("No alps::mpi::reduce available for this type " + std::string(typeid(T).name()) + ALPS_STACKTRACE);
                 }
 
-                template<typename T, typename Op> void reduce_impl(const alps::mpi::communicator & comm, T const & in_values, T & out_values, Op op, int root, boost::false_type, boost::false_type) {
+                template<typename T, typename Op> void reduce_impl(const alps::mpi::communicator & comm, T const & in_values, T & out_values, Op /*op*/, int root, boost::false_type, boost::false_type) {
                     using alps::hdf5::is_vectorizable;
                     if (is_vectorizable(in_values)) {
                         using alps::hdf5::get_extent;

--- a/accumulators/include/alps/accumulators/wrapper_set.hpp
+++ b/accumulators/include/alps/accumulators/wrapper_set.hpp
@@ -32,7 +32,7 @@ namespace alps {
                 bool can_load(hdf5::archive & ar) const {
                     return A::can_load(ar);
                 }
-                T * create(hdf5::archive & ar) const {
+                T * create(hdf5::archive & /*ar*/) const {
                     return new T(A());
                 }
             };

--- a/accumulators/include/alps/accumulators/wrappers.hpp
+++ b/accumulators/include/alps/accumulators/wrappers.hpp
@@ -354,16 +354,16 @@ namespace alps {
                     throw std::runtime_error("The operator /= is not implemented for accumulators, only for results" + ALPS_STACKTRACE);
                 }
             
-                void operator+=(wrapped_scalar_value_type arg) {
+                void operator+=(wrapped_scalar_value_type /*arg*/) {
                     throw std::runtime_error("The Operator += is not implemented for accumulators, only for results" + ALPS_STACKTRACE);
                 }
-                void operator-=(wrapped_scalar_value_type arg) {
+                void operator-=(wrapped_scalar_value_type /*arg*/) {
                     throw std::runtime_error("The Operator -= is not implemented for accumulators, only for results" + ALPS_STACKTRACE);
                 }
-                void operator*=(wrapped_scalar_value_type arg) {
+                void operator*=(wrapped_scalar_value_type /*arg*/) {
                     throw std::runtime_error("The Operator *= is not implemented for accumulators, only for results" + ALPS_STACKTRACE);
                 }
-                void operator/=(wrapped_scalar_value_type arg) {
+                void operator/=(wrapped_scalar_value_type /*arg*/) {
                     throw std::runtime_error("The Operator /= is not implemented for accumulators, only for results" + ALPS_STACKTRACE);
                 }
 

--- a/accumulators/test/accumulator_generator.hpp
+++ b/accumulators/test/accumulator_generator.hpp
@@ -39,7 +39,7 @@ namespace alps {
             inline void compare_near(const std::vector<T>& expected, const std::vector<T>& actual, double tol, const std::string& descr)
             {
                 EXPECT_EQ(expected.size(), actual.size()) << "Sizes of "+descr+" differ";
-                for (int i=0; i<expected.size(); ++i) {
+                for (size_t i=0; i<expected.size(); ++i) {
                     EXPECT_NEAR(expected.at(i), actual.at(i), tol) << "Element #"+boost::lexical_cast<std::string>(i)+" of "+descr+" differs";
                 }
             }
@@ -444,7 +444,7 @@ namespace alps {
                     alps::accumulators::accumulator_set& m=*measurements_ptr_;
                     m << acc_type(acc_name);
 
-                    for (int i=0; i<NPOINTS; ++i) {
+                    for (size_t i=0; i<NPOINTS; ++i) {
                         data_type sample=gen_data<data_type>(number_generator(), VSIZE);
                         m[acc_name]  << sample;
                     }

--- a/accumulators/test/accumulator_generator.hpp
+++ b/accumulators/test/accumulator_generator.hpp
@@ -57,7 +57,7 @@ namespace alps {
                 double operator()() const { return drand48(); }
 
                 /// Expected mean of first n members
-                double mean(std::size_t n) const { return 0.5; }
+                double mean(std::size_t /*n*/) const { return 0.5; }
 
                 /// Expected error bar of first n members
                 double error(std::size_t n) const { return 1./(12*std::sqrt(n-1.)); }
@@ -70,10 +70,10 @@ namespace alps {
                 double operator()() const { return ini_; }
 
                 /// Expected mean of first n members
-                double mean(std::size_t n) const { return ini_; }
+                double mean(std::size_t /*n*/) const { return ini_; }
 
                 /// Expected error bar of first n members
-                double error(std::size_t n) const { return 0; }
+                double error(std::size_t /*n*/) const { return 0; }
             };
                 
             /// Functor class generating alternating data (0.5 +/- initialized; initialized=0.5 by default)

--- a/accumulators/test/binop_mixed.cpp
+++ b/accumulators/test/binop_mixed.cpp
@@ -66,7 +66,7 @@ class AccumulatorMixedBinaryTest : public ::testing::Test {
         aset_ << left_acc_type("left")
             << right_acc_type("right");
         
-        for (int i=0; i<NPOINTS; ++i) {
+        for (size_t i=0; i<NPOINTS; ++i) {
             double v=scalar_gen_(); // both accs have the same sequence of values (FIXME?)
             aset_["left"] << aat::gen_data<value_type>(v).value();
             aset_["right"] << aat::gen_data<value_type>(v).value();

--- a/accumulators/test/binop_with_scalar.cpp
+++ b/accumulators/test/binop_with_scalar.cpp
@@ -56,7 +56,7 @@ class AccumulatorVSBinaryOpTest : public ::testing::Test {
         const vector_data_type vs_mean=res_vs.mean<vector_data_type>();                             \
                                                                                                     \
         ASSERT_EQ(vv_mean.size(),vs_mean.size()) << "Vector means sizes differ!";                   \
-        for (int i=0; i<vv_mean.size(); ++i) {                                                      \
+        for (size_t i=0; i<vv_mean.size(); ++i) {                                                      \
             EXPECT_NEAR(vv_mean[i], vs_mean[i], 1E-8) << "Vector means differ at element " << i;    \
         }                                                                                           \
                                                                                                     \
@@ -67,7 +67,7 @@ class AccumulatorVSBinaryOpTest : public ::testing::Test {
         const vector_data_type vs_err=res_vs.error<vector_data_type>();                             \
                                                                                                     \
         ASSERT_EQ(vv_err.size(),vs_err.size()) << "Vector errors sizes differ!";                    \
-        for (int i=0; i<vv_err.size(); ++i) {                                                       \
+        for (size_t i=0; i<vv_err.size(); ++i) {                                                       \
             EXPECT_NEAR(vv_err[i], vs_err[i], 1E-8) << "Vector errors differ at element " << i;     \
         }                                                                                           \
     }

--- a/accumulators/test/custom_type.hpp
+++ b/accumulators/test/custom_type.hpp
@@ -367,7 +367,7 @@ namespace alps {
             
             /// Specialization of get_extent<custom_type>
             template<typename T> struct get_extent< my_custom_type<T> > {
-                static std::vector<std::size_t> apply(const my_custom_type<T>& x) {
+                static std::vector<std::size_t> apply(const my_custom_type<T>& /*x*/) {
                     using alps::hdf5::get_extent;
                     std::vector<std::size_t> ext(1,1); // 1D object of size 1
                     return ext;
@@ -376,7 +376,7 @@ namespace alps {
             
             /// Specialization of set_extent<custom_type>
             template<typename T> struct set_extent< my_custom_type<T> > {
-                static void apply(const my_custom_type<T>& x, const std::vector<std::size_t>& ext) {
+                static void apply(const my_custom_type<T>& /*x*/, const std::vector<std::size_t>& ext) {
                     using alps::hdf5::set_extent;
                     if (ext.size()!=1 || ext[0]!=1) { // expecting 1D object of size 1
                         throw std::runtime_error("Unexpected extent values");
@@ -386,7 +386,7 @@ namespace alps {
 
             /// Specialization of is_vectorizable<custom_type>
             template<typename T> struct is_vectorizable< my_custom_type<T> > {
-                static bool apply(const my_custom_type<T>& x) {
+                static bool apply(const my_custom_type<T>& /*x*/) {
                     // return false;
                     return true;
                 }

--- a/accumulators/test/mean_wrapped.cpp
+++ b/accumulators/test/mean_wrapped.cpp
@@ -40,7 +40,7 @@ template<typename A, typename T> void mean_test_body_vector() {
 		measurements["obs2"] << std::vector<T>(L, T(i));
 		std::vector<T> mean_vec_1=measurements["obs1"].mean<std::vector<T> >();
 		std::vector<T> mean_vec_2=measurements["obs2"].mean<std::vector<T> >();
-		for(int j=0;j<mean_vec_1.size();++j){
+		for(size_t j=0;j<mean_vec_1.size();++j){
 			EXPECT_NEAR(mean_vec_1[j] , T(1.) , prec);
 			EXPECT_NEAR(mean_vec_2[j] , T(i + 1) / 2 , prec);
 		}
@@ -51,7 +51,7 @@ template<typename A, typename T> void mean_test_body_vector() {
 		std::vector<T> mean_vec_2=results["obs2"].mean<std::vector<T> >();
                 EXPECT_EQ(mean_vec_1.size(), L);
                 EXPECT_EQ(mean_vec_2.size(), L);
-		for(int i=0;i<mean_vec_1.size();++i){
+		for(size_t i=0;i<mean_vec_1.size();++i){
 	  		EXPECT_NEAR(mean_vec_1[i] , T(1.) , prec);
 			EXPECT_NEAR(mean_vec_2[i] , T(500.) , prec);
 	}

--- a/hdf5/include/alps/hdf5/archive.hpp
+++ b/hdf5/include/alps/hdf5/archive.hpp
@@ -236,7 +236,7 @@ namespace alps {
         namespace detail {
 
              template<typename T> struct get_extent {
-                static std::vector<std::size_t> apply(T const & value) {
+                static std::vector<std::size_t> apply(T const & /*value*/) {
                     return std::vector<std::size_t>();
                 }
             };
@@ -299,10 +299,11 @@ namespace alps {
                archive & ar
              , std::string const & path
              , T const & value
-             , std::vector<std::size_t> size = std::vector<std::size_t>()
+             , std::vector<std::size_t> /*size*/ = std::vector<std::size_t>()
              , std::vector<std::size_t> chunk = std::vector<std::size_t>()
-             , std::vector<std::size_t> offset = std::vector<std::size_t>()
+             , std::vector<std::size_t> /*offset*/ = std::vector<std::size_t>()
         ) {
+            // FIXME: size and offset are unused -- we should at least check for this
             if (chunk.size())
                 throw std::logic_error("user defined objects needs to be written continously" + ALPS_STACKTRACE);
             std::string context = ar.get_context();
@@ -316,7 +317,7 @@ namespace alps {
              , std::string const & path
              , T & value
              , std::vector<std::size_t> chunk = std::vector<std::size_t>()
-             , std::vector<std::size_t> offset = std::vector<std::size_t>()
+             , std::vector<std::size_t> /*offset*/ = std::vector<std::size_t>()
         ) {
             if (chunk.size())
                 throw std::logic_error("user defined objects needs to be written continously" + ALPS_STACKTRACE);

--- a/hdf5/include/alps/hdf5/boost_optional.hpp
+++ b/hdf5/include/alps/hdf5/boost_optional.hpp
@@ -15,9 +15,9 @@ namespace alps {
         template <typename T>
         void save(alps::hdf5::archive& ar, const std::string& path,
                   const boost::optional<T>& value,
-                  std::vector<std::size_t> size=std::vector<std::size_t>(),
-                  std::vector<std::size_t> chunk=std::vector<std::size_t>(),
-                  std::vector<std::size_t> offset=std::vector<std::size_t>())
+                  std::vector<std::size_t> /*size*/=std::vector<std::size_t>(),
+                  std::vector<std::size_t> /*chunk*/=std::vector<std::size_t>(),
+                  std::vector<std::size_t> /*offset*/=std::vector<std::size_t>())
         {
             if (ar.is_group(path)) ar.delete_group(path);
             if (!value) {
@@ -32,9 +32,9 @@ namespace alps {
         template <typename T>
         void load(alps::hdf5::archive& ar, const std::string& path,
                   boost::optional<T>& value,
-                  std::vector<std::size_t> size=std::vector<std::size_t>(),
-                  std::vector<std::size_t> chunk=std::vector<std::size_t>(),
-                  std::vector<std::size_t> offset=std::vector<std::size_t>())
+                  std::vector<std::size_t> /*size*/=std::vector<std::size_t>(),
+                  std::vector<std::size_t> /*chunk*/=std::vector<std::size_t>(),
+                  std::vector<std::size_t> /*offset*/=std::vector<std::size_t>())
         {
             bool is_empty=false;
             ar.read(path+"/@alps_hdf5_optional_empty", is_empty);

--- a/hdf5/include/alps/hdf5/complex.hpp
+++ b/hdf5/include/alps/hdf5/complex.hpp
@@ -32,22 +32,22 @@ namespace alps {
         namespace detail {
 
             template<typename T> struct get_extent<std::complex<T> > {
-                static std::vector<std::size_t> apply(std::complex<T> const & value) {
+                static std::vector<std::size_t> apply(std::complex<T> const & /*value*/) {
                     return std::vector<std::size_t>(1, 2);
                 }
             };
 
             template<typename T> struct set_extent<std::complex<T> > {
-                static void apply(std::complex<T> & value, std::vector<std::size_t> const & extent) {}
+                static void apply(std::complex<T> & /*value*/, std::vector<std::size_t> const & /*extent*/) {}
             };
 
             template<typename T> struct is_vectorizable<std::complex<T> > {
-                static bool apply(std::complex<T> const & value) {
+                static bool apply(std::complex<T> const & /*value*/) {
                     return true;
                 }
             };
             template<typename T> struct is_vectorizable<std::complex<T> const> {
-                static bool apply(std::complex<T> const & value) {
+                static bool apply(std::complex<T> const & /*value*/) {
                     return true;
                 }
             };

--- a/hdf5/include/alps/hdf5/multi_array.hpp
+++ b/hdf5/include/alps/hdf5/multi_array.hpp
@@ -74,7 +74,7 @@ namespace alps {
                     template<std::size_t M> static void gen_extent(boost::multi_array<T, N, A> & value, boost::detail::multi_array::extent_gen<M> extents, std::vector<std::size_t> const & size) {
                         gen_extent(value, extents[size.front()], std::vector<std::size_t>(size.begin() + 1, size.end()));
                     }
-                    static void gen_extent(boost::multi_array<T, N, A> & value, typename boost::detail::multi_array::extent_gen<N> extents, std::vector<std::size_t> const & size) {
+                    static void gen_extent(boost::multi_array<T, N, A> & value, typename boost::detail::multi_array::extent_gen<N> extents, std::vector<std::size_t> const & /*size*/) {
                         value.resize(extents);
                     }
             };

--- a/hdf5/include/alps/hdf5/pair.hpp
+++ b/hdf5/include/alps/hdf5/pair.hpp
@@ -20,9 +20,9 @@ namespace alps {
               archive & ar
             , std::string const & path
             , std::pair<T, U> const & value
-            , std::vector<std::size_t> size = std::vector<std::size_t>()
-            , std::vector<std::size_t> chunk = std::vector<std::size_t>()
-            , std::vector<std::size_t> offset = std::vector<std::size_t>()
+            , std::vector<std::size_t> /*size*/ = std::vector<std::size_t>()
+            , std::vector<std::size_t> /*chunk*/ = std::vector<std::size_t>()
+            , std::vector<std::size_t> /*offset*/ = std::vector<std::size_t>()
         ) {
             save(ar, ar.complete_path(path) + "/0", value.first);
             if (has_complex_elements<typename alps::detail::remove_cvr<T>::type>::value)
@@ -36,8 +36,8 @@ namespace alps {
               archive & ar
             , std::string const & path
             , std::pair<T, U> & value
-            , std::vector<std::size_t> chunk = std::vector<std::size_t>()
-            , std::vector<std::size_t> offset = std::vector<std::size_t>()
+            , std::vector<std::size_t> /*chunk*/ = std::vector<std::size_t>()
+            , std::vector<std::size_t> /*offset*/ = std::vector<std::size_t>()
         ) {
             try {
                 load(ar, ar.complete_path(path) + "/0", value.first);

--- a/hdf5/src/archive.cpp
+++ b/hdf5/src/archive.cpp
@@ -1211,10 +1211,10 @@ namespace alps {
                     return &value;                                                                                                                                      \
                 }                                                                                                                                                       \
                                                                                                                                                                         \
-                bool is_vectorizable< T >::apply(T const & value) {                                                                                                     \
+                bool is_vectorizable< T >::apply(T const &) {                                                                                                     \
                     return true;                                                                                                                                        \
                 }                                                                                                                                                       \
-                bool is_vectorizable< T const >::apply(T & value) {                                                                                                     \
+                bool is_vectorizable< T const >::apply(T &) {                                                                                                     \
                     return true;                                                                                                                                        \
                 }                                                                                                                                                       \
             }                                                                                                                                                           \

--- a/hdf5/test/hdf5_bool.cpp
+++ b/hdf5/test/hdf5_bool.cpp
@@ -20,9 +20,9 @@ void save(
       alps::hdf5::archive & ar
     , std::string const & path
     , E const & value
-    , std::vector<std::size_t> size = std::vector<std::size_t>()
-    , std::vector<std::size_t> chunk = std::vector<std::size_t>()
-    , std::vector<std::size_t> offset = std::vector<std::size_t>()
+    , std::vector<std::size_t> /*size*/ = std::vector<std::size_t>()
+    , std::vector<std::size_t> /*chunk*/ = std::vector<std::size_t>()
+    , std::vector<std::size_t> /*offset*/ = std::vector<std::size_t>()
 )
 {
     if( value == E1 )     ar << alps::make_pvp(path, "E1");
@@ -32,8 +32,8 @@ void load(
       alps::hdf5::archive & ar
     , std::string const & path
     , E & value
-    , std::vector<std::size_t> chunk = std::vector<std::size_t>()
-    , std::vector<std::size_t> offset = std::vector<std::size_t>()
+    , std::vector<std::size_t> /*chunk*/ = std::vector<std::size_t>()
+    , std::vector<std::size_t> /*offset*/ = std::vector<std::size_t>()
 )
 {
     std::string s;

--- a/hdf5/test/hdf5_io_types.cpp
+++ b/hdf5/test/hdf5_io_types.cpp
@@ -332,9 +332,9 @@ namespace alps {
               alps::hdf5::archive & ar
             , std::string const & path
             , enum_type const & value
-            , std::vector<std::size_t> size = std::vector<std::size_t>()
-            , std::vector<std::size_t> chunk = std::vector<std::size_t>()
-            , std::vector<std::size_t> offset = std::vector<std::size_t>()
+            , std::vector<std::size_t> /*size*/ = std::vector<std::size_t>()
+            , std::vector<std::size_t> /*chunk*/ = std::vector<std::size_t>()
+            , std::vector<std::size_t> /*offset*/ = std::vector<std::size_t>()
         ) {
             switch (value) {
                 case PLUS: ar << alps::make_pvp(path, std::string("plus")); break;
@@ -345,8 +345,8 @@ namespace alps {
               alps::hdf5::archive & ar
             , std::string const & path
             , enum_type & value
-            , std::vector<std::size_t> chunk = std::vector<std::size_t>()
-            , std::vector<std::size_t> offset = std::vector<std::size_t>()
+            , std::vector<std::size_t> /*chunk*/ = std::vector<std::size_t>()
+            , std::vector<std::size_t> /*offset*/ = std::vector<std::size_t>()
         ) {
             std::string s;
             ar >> alps::make_pvp(path, s);
@@ -364,7 +364,7 @@ namespace alps {
         namespace detail {
 
             template<> struct get_extent<enum_vec_type> {
-                static std::vector<std::size_t> apply(enum_vec_type const & value) {
+                static std::vector<std::size_t> apply(enum_vec_type const & /*value*/) {
                     return std::vector<std::size_t>();
                 }
             };
@@ -374,7 +374,7 @@ namespace alps {
             };
 
             template<> struct is_vectorizable<enum_vec_type> {
-                static bool apply(enum_vec_type const & value) {
+                static bool apply(enum_vec_type const & /*value*/) {
                     return true;
                 }
             };
@@ -439,7 +439,7 @@ template<typename T> struct creator {
     template<typename X> static base_type special(X const &) { return base_type(); }
 };
 template<typename T> struct destructor {
-    static void apply(T & value) {}
+    static void apply(T & /*value*/) {}
 };
 template<typename T> bool equal(T const & a, T const & b) {
     return a == b;

--- a/mc/include/alps/mc/mpiadapter.hpp
+++ b/mc/include/alps/mc/mpiadapter.hpp
@@ -72,7 +72,7 @@ namespace alps {
                             alps::mpi::all_reduce(communicator,
                                                   has_count,
                                                   std::plus<size_t>());
-                    if (sum_counts == communicator.size()) {
+                    if ((int)sum_counts == communicator.size()) {
                         if (communicator.rank() == 0) {
                             typename Base::observable_collection_type::value_type merged = this->measurements[*it];
                             merged.collective_merge(communicator, 0);
@@ -80,7 +80,7 @@ namespace alps {
                         } else {
                             this->measurements[*it].collective_merge(communicator, 0);
                         }
-                    } else if (sum_counts > 0 && sum_counts < communicator.size()) {
+                    } else if (sum_counts > 0 && (int)sum_counts < communicator.size()) {
                         throw std::runtime_error(*it + " was measured on only some of the MPI processes.");
                     }
                 }

--- a/mc/include/alps/mc/mpiadapter.hpp
+++ b/mc/include/alps/mc/mpiadapter.hpp
@@ -72,7 +72,7 @@ namespace alps {
                             alps::mpi::all_reduce(communicator,
                                                   has_count,
                                                   std::plus<size_t>());
-                    if ((int)sum_counts == communicator.size()) {
+                    if (static_cast<int>(sum_counts) == communicator.size()) {
                         if (communicator.rank() == 0) {
                             typename Base::observable_collection_type::value_type merged = this->measurements[*it];
                             merged.collective_merge(communicator, 0);
@@ -80,7 +80,7 @@ namespace alps {
                         } else {
                             this->measurements[*it].collective_merge(communicator, 0);
                         }
-                    } else if (sum_counts > 0 && (int)sum_counts < communicator.size()) {
+                    } else if (sum_counts > 0 && static_cast<int>(sum_counts) < communicator.size()) {
                         throw std::runtime_error(*it + " was measured on only some of the MPI processes.");
                     }
                 }

--- a/mc/test/custom_scheduler.cpp
+++ b/mc/test/custom_scheduler.cpp
@@ -33,7 +33,7 @@ class my_schecker_type {
     my_schecker_type() {}
     my_schecker_type(const alps::params&) {};
     bool pending() { return true; }
-    void update(double f) {}
+    void update(double /*f*/) {}
 };
 
 static bool stop_callback() { return false; }

--- a/params/include/alps/params/option_description_type.hpp
+++ b/params/include/alps/params/option_description_type.hpp
@@ -72,7 +72,7 @@ namespace alps {
                     }
 
                     /// Called by apply_visitor(), for a trigger_tag type
-                    void operator()(const boost::optional<trigger_tag>& a_val) const
+                    void operator()(const boost::optional<trigger_tag>& /*a_val*/) const
                     {
                         do_define<trigger_tag>::add_option(odesc_, name_, strdesc_);
                     }
@@ -95,7 +95,7 @@ namespace alps {
 
                     /// Called by apply_visitor(), for a optional<T> bound type
                     template <typename T>
-                    void operator()(const boost::optional<T>& a_val) const
+                    void operator()(const boost::optional<T>& /*a_val*/) const
                     {
                         if (anyval_.empty()) {
                             opt_.reset<T>();
@@ -105,7 +105,7 @@ namespace alps {
                     }
 
                     /// Called by apply_visitor(), for a optional<std::string> bound type
-                    void operator()(const boost::optional<std::string>& a_val) const
+                    void operator()(const boost::optional<std::string>& /*a_val*/) const
                     {
                         if (anyval_.empty()) {
                             opt_.reset<std::string>();
@@ -155,7 +155,7 @@ namespace alps {
                    }
 
                     /// Called when the variant contains optional<trigger_tag>
-                    void operator()(const boost::optional<trigger_tag>& val) const
+                    void operator()(const boost::optional<trigger_tag>& /*val*/) const
                     {
                         // trigger options do not have defaults
                         ar_[name_] << false;

--- a/params/include/alps/params/option_type.hpp
+++ b/params/include/alps/params/option_type.hpp
@@ -125,7 +125,7 @@ namespace alps {
 
                 /// Called when the contained type LHS_T and rhs type RHS_T are distinct, non-convertible types
                 template <typename LHS_T>
-                void apply(boost::optional<LHS_T>& lhs,
+                void apply(boost::optional<LHS_T>& /*lhs*/,
                            typename boost::disable_if< detail::is_convertible<RHS_T,LHS_T> >::type* =0) const
                 {
                     throw visitor_type_mismatch(
@@ -231,7 +231,7 @@ namespace alps {
 
                 /// Types are not convertible
                 template <typename RHS_T>
-                LHS_T apply(const RHS_T& val,
+                LHS_T apply(const RHS_T& /*val*/,
                             typename boost::disable_if< detail::is_convertible<RHS_T,LHS_T> >::type* =0) const {
                     throw visitor_type_mismatch(
                         std::string("Attempt to assign an option_type object containing a value of type \"")
@@ -287,7 +287,7 @@ namespace alps {
                 }
 
                 /// Called by apply_visitor() for a bound type None
-                bool operator()(const None& val) const
+                bool operator()(const None& /*val*/) const
                 {
                     throw std::logic_error("Checking convertibility of type None --- should not be needed?"); // FIXME???
                 }
@@ -378,7 +378,7 @@ namespace alps {
                 { }
 
                 template <typename T>
-                bool can_read(const T* dummy)
+                bool can_read(const T* /*dummy*/)
                 {
                     bool ok=ar_.is_datatype<T>(name_);
                     ok &= ar_.is_scalar(name_);
@@ -386,7 +386,7 @@ namespace alps {
                 }
 
                 template <typename T>
-                bool can_read(const std::vector<T>* dummy)
+                bool can_read(const std::vector<T>* /*dummy*/)
                 {
                     bool ok=ar_.is_datatype<T>(name_);
                     ok &= !ar_.is_scalar(name_);
@@ -394,7 +394,7 @@ namespace alps {
                 }
 
                 template <typename T>
-                option_type read(const T* dummy)
+                option_type read(const T* /*dummy*/)
                 {
                     T val;
                     ar_[name_] >> val;
@@ -654,8 +654,8 @@ namespace alps {
                 }
 
                 /// Add option with default value: should never be called (a plug to keep boost::variant happy)
-                static void add_option(boost::program_options::options_description& a_opt_descr,
-                                       const std::string& optname, const std::vector<T>& defval, const std::string& a_descr)
+                static void add_option(boost::program_options::options_description& /*a_opt_descr*/,
+                                       const std::string& /*optname*/, const std::vector<T>& /*defval*/, const std::string& /*a_descr*/)
                 {
                     throw std::logic_error("Should not happen: setting default value for vector/list parameter");
                 }

--- a/params/include/alps/params/param_types.hpp
+++ b/params/include/alps/params/param_types.hpp
@@ -60,7 +60,7 @@ namespace alps {
             struct None {};
 
             /// Output operator for the "empty value" (@throws runtime_error always)
-            inline std::ostream& operator<<(std::ostream& s, const None&)
+            inline std::ostream& operator<<(std::ostream& /*s*/, const None&)
             {
                 throw std::runtime_error("Attempt to print uninitialized option value");
             }

--- a/params/include/alps/params/params_impl.hpp
+++ b/params/include/alps/params/params_impl.hpp
@@ -220,7 +220,7 @@ namespace alps {
             }
 
             /// Even though this overload must be defined, it should never be called
-            void operator()(const boost::optional<detail::trigger_tag>& val) const
+            void operator()(const boost::optional<detail::trigger_tag>& /*val*/) const
             {
                 throw std::runtime_error("Internal error");
             }

--- a/params/src/params.cpp
+++ b/params/src/params.cpp
@@ -415,7 +415,7 @@ namespace alps{
         namespace detail {
             // Validator for strings
             void validate(boost::any& outval, const std::vector<std::string>& strvalues,
-                          string_container* target_type, int)
+                          string_container* /*target_type*/, int)
             {
                 namespace po=boost::program_options;
                 namespace pov=po::validators;

--- a/params/test/apply.cpp
+++ b/params/test/apply.cpp
@@ -59,10 +59,10 @@ struct apply_test_functor {
 
     /// Unexpected option type
     template <typename T>
-    void operator()(const std::string& name,
-                    boost::optional<T> const& val,
-                    boost::optional<T> const& defval,
-                    const std::string& descr) const {
+    void operator()(const std::string& /*name*/,
+                    boost::optional<T> const& /*val*/,
+                    boost::optional<T> const& /*defval*/,
+                    const std::string& /*descr*/) const {
         FAIL();
     }
 };
@@ -104,8 +104,8 @@ struct foreach_test_functor {
 
     /// Unexpected option type
     template <typename T>
-    void operator()(const std::string& name, boost::optional<T> const& val, \
-                    boost::optional<T> const& defval, const std::string& descr) const {
+    void operator()(const std::string& /*name*/, boost::optional<T> const& /*val*/, \
+                    boost::optional<T> const& /*defval*/, const std::string& /*descr*/) const {
         FAIL();
     }
 };

--- a/utilities/include/alps/numeric/check_size.hpp
+++ b/utilities/include/alps/numeric/check_size.hpp
@@ -41,7 +41,7 @@ namespace alps {
         }
 
         template<typename T, typename U>
-        inline void check_size(T & a, U const & b) {}
+        inline void check_size(T & /*a*/, U const & /*b*/) {}
 
         template<typename T, typename U>
         inline void check_size(std::vector<T> & a, std::vector<U> const & b) {

--- a/utilities/include/alps/utilities/cast.hpp
+++ b/utilities/include/alps/utilities/cast.hpp
@@ -39,7 +39,7 @@ namespace alps {
 
         template<
             typename U, typename T, typename X
-        > inline U cast_generic(T arg, X) {
+        > inline U cast_generic(T /*arg*/, X) {
             throw bad_cast(
                   std::string("cannot cast from ") 
                 + typeid(T).name() 

--- a/utilities/include/alps/utilities/mpi.hpp
+++ b/utilities/include/alps/utilities/mpi.hpp
@@ -324,7 +324,7 @@ namespace alps {
         /// Performs MPI_Allreduce for array of a primitive type, T[n]
         template <typename T, typename OP>
         void all_reduce(const alps::mpi::communicator& comm, const T* val, int n,
-                        T* out_val, const OP& op)
+                        T* out_val, const OP& /*op*/)
         {
             if (n<=0) {
                 throw std::invalid_argument("Non-positive array size in mpi::all_reduce()");

--- a/utilities/include/alps/utilities/mpi.hpp
+++ b/utilities/include/alps/utilities/mpi.hpp
@@ -276,7 +276,7 @@ namespace alps {
         
         /// Returns MPI datatype for the value of type `T`
         template <typename T>
-        MPI_Datatype get_mpi_datatype(const T& val) {
+        MPI_Datatype get_mpi_datatype(const T&) {
             return detail::mpi_type<T>();
         }
 

--- a/utilities/test/inf.cpp
+++ b/utilities/test/inf.cpp
@@ -39,7 +39,7 @@ struct InfinityTest : public ::testing::Test {
         // using std::isinf;
         vector_type inf=alps::numeric::inf<vector_type>(vector_);
         ASSERT_EQ(vector_.size(), inf.size());
-        for (int i=0; i<inf.size(); ++i) {
+        for (size_t i=0; i<inf.size(); ++i) {
             EXPECT_TRUE((boost::math::isinf)(inf[i]));
         }
     }
@@ -48,9 +48,9 @@ struct InfinityTest : public ::testing::Test {
         // using std::isinf;
         vector_vector_type inf=alps::numeric::inf<vector_vector_type>(vector_vector_);
         ASSERT_EQ(vector_vector_.size(), inf.size());
-        for (int i=0; i<inf.size(); ++i) {
+        for (size_t i=0; i<inf.size(); ++i) {
             ASSERT_EQ(vector_vector_[i].size(), inf[i].size());
-            for (int j=0; j<inf[i].size(); ++j) {
+            for (size_t j=0; j<inf[i].size(); ++j) {
                 EXPECT_TRUE((boost::math::isinf)(inf[i][j]));
             }
         }

--- a/utilities/test/mpi_test_support.cpp
+++ b/utilities/test/mpi_test_support.cpp
@@ -11,7 +11,7 @@
 // Intercept MPI_Abort to verify it was indeed called
 static int Mpi_abort_called=0;
 /// This function detects MPI_Abort() call
-extern "C" int MPI_Abort(MPI_Comm comm, int rc)
+extern "C" int MPI_Abort(MPI_Comm /*comm*/, int /*rc*/)
 {
     ++Mpi_abort_called;
     return 0;

--- a/utilities/test/test_utils_test.cpp
+++ b/utilities/test/test_utils_test.cpp
@@ -45,11 +45,11 @@ class TestUtilsTest : public ::testing::Test {
         const unsigned int nvals=range<value_type>::VALUE;
         std::vector<value_type> vals(nvals);
 
-        for (int i=0; i<(int)nvals; ++i) {
+        for (int i=0; i<static_cast<int>(nvals); ++i) {
             vals[i]=alps::testing::datapoint<value_type>::get(i);
         }
-        for (int i=0; i<(int)nvals; ++i) {
-            for (int j=i+1; j<(int)nvals; ++j) {
+        for (int i=0; i<static_cast<int>(nvals); ++i) {
+            for (int j=i+1; j<static_cast<int>(nvals); ++j) {
                 ASSERT_NE(vals[i], vals[j]) << "Value clash at i=" << i << ", j=" << j;
             }
         }
@@ -75,11 +75,11 @@ class TestUtilsTest : public ::testing::Test {
         const unsigned int nvals=range<value_type>::VALUE;
         std::vector<value_type> vals(nvals);
 
-        for (int i=0; i<(int)nvals; ++i) {
+        for (int i=0; i<static_cast<int>(nvals); ++i) {
             vals[i]=alps::testing::datapoint<value_type>::get(i,10);
         }
-        for (int i=0; i<(int)nvals; ++i) {
-            for (int j=i+1; j<(int)nvals; ++j) {
+        for (int i=0; i<static_cast<int>(nvals); ++i) {
+            for (int j=i+1; j<static_cast<int>(nvals); ++j) {
                 ASSERT_NE(vals[i], vals[j]) << "Value clash at i=" << i << ", j=" << j;
             }
         }
@@ -105,11 +105,11 @@ class TestUtilsTest : public ::testing::Test {
         const unsigned int nvals=range<value_type>::VALUE;
         std::vector<vector_type> vals(nvals);
 
-        for (int i=0; i<(int)nvals; ++i) {
+        for (int i=0; i<static_cast<int>(nvals); ++i) {
             vals[i]=alps::testing::datapoint<vector_type>::get(i);
         }
-        for (int i=0; i<(int)nvals; ++i) {
-            for (int j=i+1; j<(int)nvals; ++j) {
+        for (int i=0; i<static_cast<int>(nvals); ++i) {
+            for (int j=i+1; j<static_cast<int>(nvals); ++j) {
                 ASSERT_NE(vals[i], vals[j]) << "Value clash at i=" << i << ", j=" << j;
             }
         }
@@ -137,11 +137,11 @@ class TestUtilsTest : public ::testing::Test {
         const unsigned int nvals=range<value_type>::VALUE;
         std::vector<vector_type> vals(nvals);
 
-        for (int i=0; i<(int)nvals; ++i) {
+        for (int i=0; i<static_cast<int>(nvals); ++i) {
             vals[i]=alps::testing::datapoint<vector_type>::get(i,sz);
         }
-        for (int i=0; i<(int)nvals; ++i) {
-            for (int j=i+1; j<(int)nvals; ++j) {
+        for (int i=0; i<static_cast<int>(nvals); ++i) {
+            for (int j=i+1; j<static_cast<int>(nvals); ++j) {
                 ASSERT_NE(vals[i], vals[j]) << "Value clash at i=" << i << ", j=" << j;
             }
         }
@@ -206,11 +206,11 @@ TYPED_TEST(TestUtilsStringTest, StringWithSize) {
     const unsigned int nvals=range<value_type>::VALUE;
     std::vector<value_type> vals(nvals);
     
-    for (int i=0; i<(int)nvals; ++i) {
+    for (int i=0; i<static_cast<int>(nvals); ++i) {
         vals[i]=alps::testing::datapoint<value_type>::get(i,sz);
     }
-    for (int i=0; i<(int)nvals; ++i) {
-        for (int j=i+1; j<(int)nvals; ++j) {
+    for (int i=0; i<static_cast<int>(nvals); ++i) {
+        for (int j=i+1; j<static_cast<int>(nvals); ++j) {
             ASSERT_NE(vals[i], vals[j]) << "Value clash at i=" << i << ", j=" << j;
         }
     }

--- a/utilities/test/test_utils_test.cpp
+++ b/utilities/test/test_utils_test.cpp
@@ -45,11 +45,11 @@ class TestUtilsTest : public ::testing::Test {
         const unsigned int nvals=range<value_type>::VALUE;
         std::vector<value_type> vals(nvals);
 
-        for (int i=0; i<nvals; ++i) {
+        for (int i=0; i<(int)nvals; ++i) {
             vals[i]=alps::testing::datapoint<value_type>::get(i);
         }
-        for (int i=0; i<nvals; ++i) {
-            for (int j=i+1; j<nvals; ++j) {
+        for (int i=0; i<(int)nvals; ++i) {
+            for (int j=i+1; j<(int)nvals; ++j) {
                 ASSERT_NE(vals[i], vals[j]) << "Value clash at i=" << i << ", j=" << j;
             }
         }
@@ -75,11 +75,11 @@ class TestUtilsTest : public ::testing::Test {
         const unsigned int nvals=range<value_type>::VALUE;
         std::vector<value_type> vals(nvals);
 
-        for (int i=0; i<nvals; ++i) {
+        for (int i=0; i<(int)nvals; ++i) {
             vals[i]=alps::testing::datapoint<value_type>::get(i,10);
         }
-        for (int i=0; i<nvals; ++i) {
-            for (int j=i+1; j<nvals; ++j) {
+        for (int i=0; i<(int)nvals; ++i) {
+            for (int j=i+1; j<(int)nvals; ++j) {
                 ASSERT_NE(vals[i], vals[j]) << "Value clash at i=" << i << ", j=" << j;
             }
         }
@@ -105,11 +105,11 @@ class TestUtilsTest : public ::testing::Test {
         const unsigned int nvals=range<value_type>::VALUE;
         std::vector<vector_type> vals(nvals);
 
-        for (int i=0; i<nvals; ++i) {
+        for (int i=0; i<(int)nvals; ++i) {
             vals[i]=alps::testing::datapoint<vector_type>::get(i);
         }
-        for (int i=0; i<nvals; ++i) {
-            for (int j=i+1; j<nvals; ++j) {
+        for (int i=0; i<(int)nvals; ++i) {
+            for (int j=i+1; j<(int)nvals; ++j) {
                 ASSERT_NE(vals[i], vals[j]) << "Value clash at i=" << i << ", j=" << j;
             }
         }
@@ -137,11 +137,11 @@ class TestUtilsTest : public ::testing::Test {
         const unsigned int nvals=range<value_type>::VALUE;
         std::vector<vector_type> vals(nvals);
 
-        for (int i=0; i<nvals; ++i) {
+        for (int i=0; i<(int)nvals; ++i) {
             vals[i]=alps::testing::datapoint<vector_type>::get(i,sz);
         }
-        for (int i=0; i<nvals; ++i) {
-            for (int j=i+1; j<nvals; ++j) {
+        for (int i=0; i<(int)nvals; ++i) {
+            for (int j=i+1; j<(int)nvals; ++j) {
                 ASSERT_NE(vals[i], vals[j]) << "Value clash at i=" << i << ", j=" << j;
             }
         }
@@ -206,11 +206,11 @@ TYPED_TEST(TestUtilsStringTest, StringWithSize) {
     const unsigned int nvals=range<value_type>::VALUE;
     std::vector<value_type> vals(nvals);
     
-    for (int i=0; i<nvals; ++i) {
+    for (int i=0; i<(int)nvals; ++i) {
         vals[i]=alps::testing::datapoint<value_type>::get(i,sz);
     }
-    for (int i=0; i<nvals; ++i) {
-        for (int j=i+1; j<nvals; ++j) {
+    for (int i=0; i<(int)nvals; ++i) {
+        for (int j=i+1; j<(int)nvals; ++j) {
             ASSERT_NE(vals[i], vals[j]) << "Value clash at i=" << i << ", j=" << j;
         }
     }


### PR DESCRIPTION
Fixes #375 by fixing most instances of two types of warnings:

 * signed/unsigned integer comparison
 * unused parameters
