### PR TITLE
Disable assignment of hdf5::archive objects

### DIFF
--- a/hdf5/include/alps/hdf5/archive.hpp
+++ b/hdf5/include/alps/hdf5/archive.hpp
@@ -90,6 +90,9 @@ namespace alps {
         }
 
         class archive {
+            private:
+               /// Assignment operator is deleted
+               archive& operator=(const archive&); /* not implemented*/ // FIXME:TODO:C++11 `=delete` or implement via `swap()`
             // FIXME: MAKE private:
             public:
                 typedef enum {


### PR DESCRIPTION
Patches over issue #381 