### PR TITLE
Meta-predicate for "native types" in alps::hdf5

### DIFF
--- a/hdf5/include/alps/hdf5/archive.hpp
+++ b/hdf5/include/alps/hdf5/archive.hpp
@@ -19,6 +19,7 @@
 
 #include <boost/mpl/and.hpp>
 #include <boost/utility/enable_if.hpp>
+#include <boost/type_traits/integral_constant.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/is_array.hpp>
 #include <boost/type_traits/remove_all_extents.hpp>
@@ -54,6 +55,15 @@
 
 namespace alps {
     namespace hdf5 {
+
+        /// Inherits from `true_type` if `T` is a native type, from `false_type` otherwise
+        template <typename T>
+        struct is_native_type : public boost::false_type {};
+#define ALPS_HDF5_IS_NATIVE_TYPE_CALLER(__type__)    \
+        template <> struct is_native_type<__type__> : public boost::true_type {};
+        ALPS_FOREACH_NATIVE_HDF5_TYPE(ALPS_HDF5_IS_NATIVE_TYPE_CALLER)
+#undef ALPS_HDF5_IS_NATIVE_TYPE_CALLER
+
 
         namespace detail {
             struct archivecontext;

--- a/hdf5/test/CMakeLists.txt
+++ b/hdf5/test/CMakeLists.txt
@@ -9,6 +9,7 @@ set (test_src
     hdf5_exceptions
     hdf5_memory
     hdf5_misc
+    hdf5_native_type    
     hdf5_multiarchive
     hdf5_pair
     hdf5_real_complex

--- a/hdf5/test/hdf5_native_type.cpp
+++ b/hdf5/test/hdf5_native_type.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 1998-2017 ALPS Collaboration. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ * For use in publications, see ACKNOWLEDGE.TXT
+ */
+
+/** @file hdf5_native_type.cpp
+    Tests `alps::hdf5::native_type` meta-predicate.
+*/
+
+#include <alps/hdf5/archive.hpp>
+#include <alps/hdf5/vector.hpp>
+
+#include <boost/type_traits/is_same.hpp>
+#include <gtest/gtest.h>
+
+namespace h5=alps::hdf5;
+
+template <typename T>
+void testNative(const char* name_of_type) {
+    typedef h5::is_native_type<T> test_type;
+    EXPECT_TRUE(+test_type::value) << name_of_type;
+    EXPECT_TRUE((boost::is_same<typename test_type::type, boost::true_type>::value)) << name_of_type;
+}
+    
+template <typename T>
+void testNotNative(const char* name_of_type) {
+    typedef h5::is_native_type<T> test_type;
+    EXPECT_FALSE(+test_type::value) << name_of_type;
+    EXPECT_TRUE((boost::is_same<typename test_type::type, boost::false_type>::value)) << name_of_type;
+}
+
+TEST(Hdf5NativeTypeTest, native) {
+    testNative<char>("char");
+    testNative<signed char>("signed char");
+    testNative<unsigned char>("unsigned char");
+    testNative<short>("short");
+    testNative<unsigned short>("unsigned short");
+    testNative<int>("int");
+    testNative<unsigned>("unsigned");
+    testNative<long>("long");
+    testNative<unsigned long>("unsigned long");
+    testNative<long long>("long long");
+    testNative<unsigned long long>("unsigned long long");
+    testNative<float>("float");
+    testNative<double>("double");
+    testNative<long double>("long double");
+    testNative<bool>("bool");
+    testNative<std::string>("std::string");
+}
+
+struct some_class {};
+
+TEST(Hdf5NativeTypeTest, notNative) {
+    testNotNative<int*>("int*");
+    testNotNative<void>("void");
+    testNotNative< std::vector<int> >(" std::vector<int");
+    testNotNative< some_class >(" some_class ");
+}


### PR DESCRIPTION
A simple fix for issue #383.
