### PR TITLE
Small bug fix

### DIFF
--- a/params/include/alps/params/mpi_variant.hpp
+++ b/params/include/alps/params/mpi_variant.hpp
@@ -25,7 +25,7 @@ namespace alps {
     namespace mpi {
 
         inline void broadcast(const alps::mpi::communicator&, alps::params_ns::detail::None&, int) {
-            std::cout << "DEBUG: Broadcasting None is no-op" << std::endl;
+            //std::cout << "DEBUG: Broadcasting None is no-op" << std::endl;
         }
         
         namespace detail {


### PR DESCRIPTION
This debug code requires inclusion of iostream. 
This would introduce an unnecessary dependency on iostream.
With this fix, the CT-HYB code now runs correctly with deboost-version of ALPSCore.