### PR TITLE
Output message for found wrong version of eigen3

### DIFF
--- a/common/cmake/ALPSEnableEigen.cmake
+++ b/common/cmake/ALPSEnableEigen.cmake
@@ -22,11 +22,38 @@ function(add_eigen)
 
   if (NOT ALPS_INSTALL_EIGEN)
     find_package(Eigen3 ${ALPS_EIGEN_MIN_VERSION})
-    if (NOT EIGEN3_FOUND) # CMake 3.3+ would use Eigen3_FOUND
+    if (NOT EIGEN3_FOUND AND NOT DEFINED EIGEN3_VERSION_OK) # CMake 3.3+ would use Eigen3_FOUND
       message(FATAL_ERROR
 " 
  The required library Eigen3 has not been found on your system.
  Your could try the following options:
+ 1. Set environment variable Eigen3_DIR
+    to point to the root of your CMake-based Eigen3 installation.
+ 2. Rerun CMake with option:
+     -DEIGEN3_INCLUDE_DIR=<path to your Eigen3 directory> 
+    to point to the location of Eigen3 headers.
+ 3. Rerun CMake with option:
+     -DALPS_INSTALL_EIGEN=true 
+    to request the installation script to attempt to download Eigen3
+    and co-install it with ALPSCore.
+
+    In the latter case, you may optionally also set:
+     -DALPS_EIGEN_UNPACK_DIR=<path to directory to unpack Eigen> 
+     (currently set to ${ALPS_EIGEN_UNPACK_DIR})
+
+     -DALPS_EIGEN_TGZ_FILE=<path to Eigen3 archive file>
+     (currently set to ${ALPS_EIGEN_TGZ_FILE})
+
+     -DEIGEN3_INSTALL_DIR=<path to unpacked Eigen3>
+     (if you want to co-install a specific version of Eigen)
+
+")
+  elseif(NOT EIGEN3_FOUND AND DEFINED EIGEN3_VERSION_OK)
+    message(FATAL_ERROR
+" 
+ The required library Eigen3 has been found at ${EIGEN3_INCLUDE_DIR} on your system.
+ We require ${ALPS_EIGEN_MIN_VERSION} > ${EIGEN3_VERSION}
+ Please try upgrading or using the following options to use a different installation:
  1. Set environment variable Eigen3_DIR
     to point to the root of your CMake-based Eigen3 installation.
  2. Rerun CMake with option:


### PR DESCRIPTION
When I was compiling `ALPSCore` my installation found my Eigen3 installation but continued to output the same message (which made me think I was doing something wrong). To help with the confusion the "header" of the message will now explain the wrong version has been found. An example:
```
-- eigen requested
-- Eigen3 version 3.3.1 found in /Users/ryle/modules/eigen331, but at least version 3.3.4 is required
-- Could NOT find Eigen3 (missing:  EIGEN3_VERSION_OK) (Required is at least version "3.3.4")
CMake Error at common/cmake/ALPSEnableEigen.cmake:52 (message):

The required library Eigen3 has been found at /Users/ryle/modules/eigen331 on your system.
   We require 3.3.4 > 3.3.1
   Please try upgrading or using the following options to use a different installation:
   1. Set environment variable Eigen3_DIR
...
```