### PR TITLE
Fix paths in lmod file

### DIFF
--- a/common/misc/alpscore.lmod.in
+++ b/common/misc/alpscore.lmod.in
@@ -3,7 +3,7 @@
 set     name        alpscore
 set     root        "@CMAKE_INSTALL_PREFIX@"
 
-setenv      ALPSCore_DIR    $root
+setenv      ALPSCore_DIR    $root/share/ALPSCore
+setenv      ALPSCore_ROOT   $root
 
 prepend-path      LD_LIBRARY_PATH   $root/lib
-prepend-path      CMAKE_MODULE_PATH   $root/share/ALPSCore


### PR DESCRIPTION
`ALPSCore_DIR` needs to be the install/share/ALPSCore directory; `CMAKE_MODULE_PATH ` is for `FindALPScore.cmake` which isn't provided. 

Using just `ALPSCore_DIR=$root` leads to an error of  "Could NOT find ALPSCore (missing: ALPSCore_LIBRARIES)"