### PR TITLE
 ALEA: fixed some bugs and added serialization

### DIFF
--- a/alea/include/alps/alea/autocorr.hpp
+++ b/alea/include/alps/alea/autocorr.hpp
@@ -72,7 +72,7 @@ public:
     size_t size() const { return size_; }
 
     /** Add computed vector to the accumulator */
-    autocorr_acc &operator<<(const computed<T> &source);
+    autocorr_acc &operator<<(const computed<T> &src) { add(src, 1); return *this; }
 
     /** Add Eigen vector-valued expression to accumulator */
     template <typename Derived>
@@ -99,6 +99,8 @@ public:
     const level_acc_type &level(size_t i) const { return level_[i]; }
 
 protected:
+    void add(const computed<T> &source, size_t count);
+
     void add_level();
 
     void finalize_to(autocorr_result<T> &result);

--- a/alea/include/alps/alea/autocorr.hpp
+++ b/alea/include/alps/alea/autocorr.hpp
@@ -169,7 +169,7 @@ public:
     void reduce(const reducer &r) { reduce(r, true, true); }
 
     /** Convert result to a permanent format (write to disk etc.) */
-    void serialize(serializer &);
+    void serialize(serializer &) const;
 
     size_t find_level(size_t min_samples) const;
 

--- a/alea/include/alps/alea/autocorr.hpp
+++ b/alea/include/alps/alea/autocorr.hpp
@@ -16,6 +16,8 @@
 namespace alps { namespace alea {
     template <typename T> class autocorr_acc;
     template <typename T> class autocorr_result;
+
+    template <typename T> class batch_result;
 }}
 
 // Actual declarations
@@ -108,6 +110,8 @@ protected:
 private:
     size_t size_, batch_size_, count_, nextlevel_, granularity_;
     std::vector<level_acc_type> level_;
+
+    friend class batch_result<T>;
 };
 
 template <typename T>
@@ -181,7 +185,7 @@ protected:
     void reduce(const reducer &r, bool do_pre_commit, bool do_post_commit);
 
 private:
-    const static size_t default_min_samples = 256;
+    const static size_t DEFAULT_MIN_SAMPLES = 1024;
     std::vector<level_result_type> level_;
 
     friend class autocorr_acc<T>;

--- a/alea/include/alps/alea/autocorr.hpp
+++ b/alea/include/alps/alea/autocorr.hpp
@@ -25,15 +25,15 @@ namespace alps { namespace alea {
 /**
  * Accumulator for the integrated autocorrelation time.
  *
- * The integrated autocorrelation time `tau_int` of a time series is defined
- * as the large-n limit of:
+ * The integrated autocorrelation time `tau_int` of a time series can be
+ * defined as the large-n limit of:
  *
- *                   1 + 2 * tau_int = n * var(n) / var(1),                (A)
+ *                   1 + 2 * tau_int = var(n) / var(1),                    (A)
  *
- * where `var(n)` is the sample variance obtained when averaging over batches
- * batches, each batch being the mean of `n` consecutive elements of the series.
- * Given a simulation of `N` steps, its corresponding squared error `sq_error`
- * must thus be corrected as:
+ * where `var(n)` is the sample variance obtained when averaging over batches,
+ * each batch being the sum of `n` consecutive elements of the series. Given a
+ * simulation of `N` steps, its corresponding squared error of the mean
+ * `sq_error` must thus be corrected as:
  *
  *                sq_error = (1 + 2 * tau_int) * var(1) / N                (B)
  *

--- a/alea/include/alps/alea/batch.hpp
+++ b/alea/include/alps/alea/batch.hpp
@@ -92,7 +92,7 @@ public:
     size_t size() const { return size_; }
 
     /** Add computed vector to the accumulator */
-    batch_acc &operator<<(const computed<T> &source);
+    batch_acc &operator<<(const computed<T> &src) { add(src, 1); return *this; }
 
     /** Add Eigen vector-valued expression to accumulator */
     template <typename Derived>
@@ -124,6 +124,8 @@ public:
     size_t current_batch_size() const { return base_size_ * cursor_.factor(); }
 
 protected:
+    void add(const computed<T> &source, size_t count);
+
     void next_batch();
 
     void finalize_to(batch_result<T> &result);

--- a/alea/include/alps/alea/batch.hpp
+++ b/alea/include/alps/alea/batch.hpp
@@ -189,6 +189,9 @@ public:
     template <typename Strategy=circular_var>
     column<typename bind<Strategy,T>::cov_type> cov() const;
 
+    /** Return standard error of the mean */
+    column<typename bind<circular_var,T>::var_type> stderror() const;
+
     /** Return backend object used for storing estimands */
     const batch_data<T> &store() const { return *store_; }
 
@@ -199,7 +202,7 @@ public:
     void reduce(const reducer &r) { reduce(r, true, true); }
 
     /** Convert result to a permanent format (write to disk etc.) */
-    void serialize(serializer &);
+    void serialize(serializer &) const;
 
 protected:
     void reduce(const reducer &r, bool do_pre_commit, bool do_post_commit);

--- a/alea/include/alps/alea/bundle.hpp
+++ b/alea/include/alps/alea/bundle.hpp
@@ -20,23 +20,23 @@ template <typename T>
 class bundle
 {
 public:
-    bundle(size_t size, size_t cap) : sum_(size), capacity_(cap) { reset(); }
+    bundle(size_t size, size_t target) : sum_(size), target_(target) { reset(); }
 
     /** Re-allocate and thus clear all accumulated data */
     void reset() { sum_.fill(0); count_ = 0; }
 
-    bool is_full() { assert(count_ <= capacity_); return count_ == capacity_; }
+    bool is_full() { return count_ >= target_; }
 
     /** Number of components of the random vector (e.g., size of mean) */
     size_t size() const { return sum_.rows(); }
 
-    size_t &capacity() { return capacity_; }
+    size_t &target() { return target_; }
 
-    const size_t &capacity() const { return capacity_; }
+    const size_t &target() const { return target_; }
 
     size_t &count() { return count_; }
 
-    const size_t &count() const { return count_; }
+    size_t count() const { return count_; }
 
     column<T> &sum() { return sum_; }
 
@@ -44,7 +44,7 @@ public:
 
 private:
     column<T> sum_;
-    size_t capacity_, count_;
+    size_t target_, count_;
 };
 
 }}

--- a/alea/include/alps/alea/complex_op.hpp
+++ b/alea/include/alps/alea/complex_op.hpp
@@ -41,6 +41,9 @@ namespace alps { namespace alea {
  * (The elements are laid out in that way as well.) If one identifies the
  * imaginary part of the result with the prefactor of 'j', then `complex_op`
  * is equivalent to a quarternion `a + b*i + c*j + d*k`.
+ *
+ * Note that `dot(a, b)` must be used to multiply two complex_op instances and
+ * `solve(a, b)` for division because multiplication is not commutative.
  */
 template <typename T>
 class complex_op
@@ -102,10 +105,6 @@ public:
         return *this;
     }
 
-    complex_op &operator*=(complex_op x) { return *this = *this * x; }
-
-    complex_op &operator/=(complex_op x) { return *this = *this / x; }
-
     complex_op &operator*=(double x)
     {
         vals_[0][0] *= x;
@@ -132,7 +131,19 @@ public:
         return complex_op(l) -= r;
     }
 
-    friend complex_op operator*(complex_op l, complex_op r)
+    friend complex_op operator*(complex_op x, double f)
+    {
+        return complex_op(x) *= f;
+    }
+
+    friend complex_op operator*(double f, complex_op x) { return x * f; }
+
+    friend complex_op operator/(complex_op x, double f)
+    {
+        return complex_op(x) /= f;
+    }
+
+    friend complex_op dot(complex_op l, complex_op r)
     {
         // Matrix multiplication of two 2x2 matrices
         return complex_op(l.rere() * r.rere() + l.reim() * r.imre(),
@@ -141,27 +152,9 @@ public:
                           l.imre() * r.reim() + l.imim() * r.imim());
     }
 
-    friend complex_op operator*(complex_op x, double f)
+    friend complex_op solve(complex_op l, complex_op r)
     {
-        return complex_op(x) *= f;
-    }
-
-    friend complex_op operator*(double f, complex_op x) { return x * f; }
-
-    friend std::complex<T> operator*(complex_op op, std::complex<T> x)
-    {
-        return std::complex<T>(op.rere() * x.real() + op.reim() * x.imag(),
-                               op.imre() * x.real() + op.imim() * x.imag());
-    }
-
-    friend complex_op operator/(complex_op l, complex_op r)
-    {
-        return l * inv(r);
-    }
-
-    friend complex_op operator/(complex_op x, double f)
-    {
-        return complex_op(x) /= f;
+        return dot(l, inv(r));
     }
 
     friend bool operator==(complex_op l, complex_op r)

--- a/alea/include/alps/alea/computed.hpp
+++ b/alea/include/alps/alea/computed.hpp
@@ -36,6 +36,12 @@ eigen_adapter<typename Derived::Scalar, Derived> make_adapter(
 }
 
 template <typename T>
+vector_adapter<T> make_adapter(const std::vector<T> &v)
+{
+    return vector_adapter<T>(v);
+}
+
+template <typename T>
 class value_adapter
     : public computed<T>
 {
@@ -59,6 +65,23 @@ public:
 private:
     T in_;
 };
+
+inline value_adapter<long> make_adapter(size_t v)  // FIXME
+{
+    return value_adapter<long>(v);
+}
+
+inline value_adapter<long> make_adapter(long v)
+{
+    return value_adapter<long>(v);
+}
+
+inline value_adapter<double> make_adapter(double v)
+{
+    return value_adapter<double>(v);
+}
+
+
 
 template <typename T>
 class vector_adapter

--- a/alea/include/alps/alea/computed.hpp
+++ b/alea/include/alps/alea/computed.hpp
@@ -28,6 +28,13 @@ namespace alps { namespace alea {
 
 namespace alps { namespace alea {
 
+template <typename Derived>
+eigen_adapter<typename Derived::Scalar, Derived> make_adapter(
+                                    const Eigen::DenseBase<Derived> &in)
+{
+    return eigen_adapter<typename Derived::Scalar, Derived>(in);
+}
+
 template <typename T>
 class value_adapter
     : public computed<T>

--- a/alea/include/alps/alea/convert.hpp
+++ b/alea/include/alps/alea/convert.hpp
@@ -75,8 +75,11 @@ struct joiner<var_result<T> >
     {
         if (first.store().count() != second.store().count())
             throw weight_mismatch();
+        if (first.batch_size() != second.batch_size())
+            throw weight_mismatch();
 
-        var_result<T> res(var_data<T>(first.size() + second.size()));
+        var_result<T> res(var_data<T>(first.size() + second.size(),
+                                      first.batch_size()));
         res.store().data().topRows(first.size()) = first.store().data();
         res.store().data().bottomRows(second.size()) = second.store().data();
         res.store().data2().topRows(first.size()) = first.store().data2();
@@ -94,8 +97,11 @@ struct joiner<cov_result<T> >
     {
         if (first.store().count() != second.store().count())
             throw weight_mismatch();
+        if (first.store().batch_size() != second.store().batch_size())
+            throw weight_mismatch();
 
-        cov_result<T> res(cov_data<T>(first.size() + second.size()));
+        cov_result<T> res(cov_data<T>(first.size() + second.size(),
+                                      first.batch_size()));
         res.store().data().topRows(first.size()) = first.store().data();
         res.store().data().bottomRows(second.size()) = second.store().data();
 

--- a/alea/include/alps/alea/core.hpp
+++ b/alea/include/alps/alea/core.hpp
@@ -255,6 +255,8 @@ struct serializer
 
     virtual void write(const std::string &key, const computed<long> &value) = 0;
 
+    virtual void write(const std::string &key, const computed<unsigned long> &value) = 0;
+
     virtual ~serializer() { }
 };
 

--- a/alea/include/alps/alea/covariance.hpp
+++ b/alea/include/alps/alea/covariance.hpp
@@ -20,6 +20,8 @@ namespace alps { namespace alea {
     template <typename T, typename Str> class cov_data;
     template <typename T, typename Str> class cov_acc;
     template <typename T, typename Str> class cov_result;
+
+    template <typename T> class batch_result;
 }}
 
 // Actual declarations
@@ -159,14 +161,13 @@ protected:
 
     void add_bundle();
 
-    void uplevel(cov_acc &new_uplevel) { uplevel_ = &new_uplevel; }
-
     void finalize_to(cov_result<T,Strategy> &result);
 
 private:
     std::unique_ptr<cov_data<T,Strategy> > store_;
     bundle<value_type> current_;
-    cov_acc *uplevel_;
+
+    friend class batch_result<T>;
 };
 
 template <typename T, typename Strategy>

--- a/alea/include/alps/alea/covariance.hpp
+++ b/alea/include/alps/alea/covariance.hpp
@@ -241,7 +241,7 @@ public:
     void reduce(const reducer &r) { reduce(r, true, true); }
 
     /** Convert result to a permanent format (write to disk etc.) */
-    void serialize(serializer &);
+    void serialize(serializer &) const;
 
 protected:
     void reduce(const reducer &, bool do_pre_commit, bool do_post_commit);

--- a/alea/include/alps/alea/covariance.hpp
+++ b/alea/include/alps/alea/covariance.hpp
@@ -118,7 +118,7 @@ public:
     size_t size() const { return current_.size(); }
 
     /** Add computed vector to the accumulator */
-    cov_acc &operator<<(const computed<T> &source);
+    cov_acc &operator<<(const computed<T> &src) { add(src, 1); return *this; }
 
     /** Add Eigen vector-valued expression to accumulator */
     template <typename Derived>
@@ -146,6 +146,8 @@ public:
     const cov_data<T,Strategy> &store() const { return *store_; }
 
 protected:
+    void add(const computed<T> &source, size_t count);
+
     void add_bundle();
 
     void uplevel(cov_acc &new_uplevel) { uplevel_ = &new_uplevel; }

--- a/alea/include/alps/alea/covariance.hpp
+++ b/alea/include/alps/alea/covariance.hpp
@@ -43,7 +43,7 @@ public:
     typedef typename eigen<cov_type>::matrix cov_matrix_type;
 
 public:
-    cov_data(size_t size);
+    cov_data(size_t size, size_t batch_size);
 
     /** Re-allocate and thus clear all accumulated data */
     void reset();
@@ -56,6 +56,12 @@ public:
 
     /** Returns sample size, i.e., number of accumulated data points */
     size_t &count() { return count_; }
+
+    /** Returns number of data points per batch */
+    size_t batch_size() const { return batch_size_; }
+
+    /** Returns number of data points per batch */
+    size_t &batch_size() { return batch_size_; }
 
     const column<value_type> &data() const { return data_; }
 
@@ -72,7 +78,7 @@ public:
 private:
     column<T> data_;
     cov_matrix_type data2_;
-    size_t count_;
+    size_t count_, batch_size_;
 };
 
 template <typename T, typename Strategy>
@@ -116,6 +122,9 @@ public:
 
     /** Number of components of the random vector (e.g., size of mean) */
     size_t size() const { return current_.size(); }
+
+    /** Returns number of data points per batch */
+    size_t batch_size() const { return current_.target(); }
 
     /** Add computed vector to the accumulator */
     cov_acc &operator<<(const computed<T> &src) { add(src, 1); return *this; }
@@ -205,6 +214,9 @@ public:
 
     /** Returns sample size, i.e., number of accumulated data points */
     size_t count() const { return store_->count(); }
+
+    /** Returns number of data points per batch */
+    size_t batch_size() const { return store_->batch_size(); }
 
     /** Returns sample mean */
     const column<T> &mean() const { return store_->data(); }

--- a/alea/include/alps/alea/hdf5.hpp
+++ b/alea/include/alps/alea/hdf5.hpp
@@ -26,6 +26,7 @@ std::string join_paths(const std::string &base, const std::string &rel)
 }
 
 class hdf5_serializer
+    : public serializer
 {
 public:
     hdf5_serializer(hdf5::archive &ar, const std::string &path)
@@ -33,25 +34,29 @@ public:
         , path_(path)
     { }
 
-    void write(const std::string &key, computed<double> &value) {
+    void write(const std::string &key, const computed<double> &value) {
         do_write(key, value);
     }
 
-    void write(const std::string &key, computed<std::complex<double> > &value) {
+    void write(const std::string &key, const computed<std::complex<double> > &value) {
         do_write(key, value);
     }
 
-    void write(const std::string &key, computed<complex_op<double> > &value) {
+    void write(const std::string &key, const computed<complex_op<double> > &value) {
         do_write(key, value);
     }
 
-    void write(const std::string &key, computed<long> &value) {
+    void write(const std::string &key, const computed<long> &value) {
+        do_write(key, value);
+    }
+
+    void write(const std::string &key, const computed<unsigned long> &value) {
         do_write(key, value);
     }
 
 protected:
     template <typename T>
-    void do_write(const std::string &relpath, computed<T> &data)
+    void do_write(const std::string &relpath, const computed<T> &data)
     {
         // Look at:
         // void archive::write(std::string path, T const * value,

--- a/alea/include/alps/alea/hdf5.hpp
+++ b/alea/include/alps/alea/hdf5.hpp
@@ -12,6 +12,10 @@
 
 #include <alps/hdf5/archive.hpp>
 
+//FIXME
+#include <iostream>
+#include <iterator>
+
 namespace alps { namespace alea {
 
 std::string join_paths(const std::string &base, const std::string &rel)
@@ -67,14 +71,22 @@ protected:
         std::string path = join_paths(path_, relpath);
 
         std::vector<size_t> shape = data.shape();
-        std::vector<size_t> offset(0, shape.size());
-        std::vector<size_t> chunk(1, shape.size());
+        std::vector<size_t> offset(shape.size(), 0);
+        std::vector<size_t> chunk = shape;
         size_t size = std::accumulate(shape.begin(), shape.end(), 1,
                                       std::multiplies<size_t>());
+
+        std::cerr << "X" << size << std::endl;
+        std::copy(shape.begin(), shape.end(), std::ostream_iterator<size_t>(std::cerr, ","));
+        std::cerr << std::endl;
+
 
         // TODO: use HDF5 dataspaces to avoid copy
         std::vector<T> buffer(size, 0);
         data.add_to(sink<T>(&buffer[0], size));
+
+        std::copy(buffer.begin(), buffer.end(), std::ostream_iterator<T>(std::cerr, ","));
+        std::cerr << std::endl;
 
         (*archive_).write(path, &buffer[0], shape, chunk, offset);
     }

--- a/alea/include/alps/alea/internal/util.hpp
+++ b/alea/include/alps/alea/internal/util.hpp
@@ -39,4 +39,31 @@ T call_vargs(std::function<T()> func, const T *)
     return func();
 }
 
-}}}
+template <typename Acc>
+typename traits<Acc>::result_type finalize(Acc &acc)
+{
+    typename traits<Acc>::result_type result;
+    acc.finalize_to(result);
+    return result;
+}
+
+template <typename Acc>
+typename traits<Acc>::result_type result(const Acc &acc)
+{
+    typename traits<Acc>::result_type result;
+    Acc copy = acc;
+    copy.finalize_to(result);
+    return result;
+}
+
+inline Eigen::Matrix<double,1,1> make_eigen_scalar(double x)
+{
+    // FIXME: this works around the fact that the following snippet chokes:
+    //
+    //     Eigen::Matrix<complex_op<double> > m;
+    //     m *= 1.0;    // wants to cast double to complex_op
+    //
+    return Eigen::Matrix<double,1,1>(x);
+}
+
+}}} /* namespace alps::alea::internal */

--- a/alea/include/alps/alea/internal/util.hpp
+++ b/alea/include/alps/alea/internal/util.hpp
@@ -56,14 +56,4 @@ typename traits<Acc>::result_type result(const Acc &acc)
     return result;
 }
 
-inline Eigen::Matrix<double,1,1> make_eigen_scalar(double x)
-{
-    // FIXME: this works around the fact that the following snippet chokes:
-    //
-    //     Eigen::Matrix<complex_op<double> > m;
-    //     m *= 1.0;    // wants to cast double to complex_op
-    //
-    return Eigen::Matrix<double,1,1>(x);
-}
-
 }}} /* namespace alps::alea::internal */

--- a/alea/include/alps/alea/mean.hpp
+++ b/alea/include/alps/alea/mean.hpp
@@ -184,7 +184,7 @@ public:
     void reduce(const reducer &r) { return reduce(r, true, true); }
 
     /** Convert result to a permanent format (write to disk etc.) */
-    void serialize(serializer &);
+    void serialize(serializer &) const;
 
 protected:
     void reduce(const reducer &, bool do_pre_commit, bool do_post_commit);

--- a/alea/include/alps/alea/mean.hpp
+++ b/alea/include/alps/alea/mean.hpp
@@ -99,7 +99,7 @@ public:
     size_t size() const { return size_; }
 
     /** Add computed vector to the accumulator */
-    mean_acc &operator<<(const computed<T> &source);
+    mean_acc &operator<<(const computed<T> &src) { add(src, 1); return *this; }
 
     /** Add Eigen vector-valued expression to accumulator */
     template <typename Derived>
@@ -125,6 +125,8 @@ public:
     const mean_data<T> &store() const { return *store_; }
 
 protected:
+    void add(const computed<T> &source, size_t count);
+
     void finalize_to(mean_result<T> &result);
 
 private:

--- a/alea/include/alps/alea/transform.hpp
+++ b/alea/include/alps/alea/transform.hpp
@@ -58,7 +58,7 @@ cov_result<T> transform(linear_prop p, const transformer<T> &tf, const InResult 
         dx = 0.125 * std::abs(in.stderror().mean());
     typename eigen<T>::matrix jac = jacobian(tf, in.mean(), dx);
 
-    cov_result<T> res(cov_data<T>(tf.out_size()));
+    cov_result<T> res(cov_data<T>(tf.out_size(), in.batch_size()));
     res.store().data() = tf(in.mean());
     res.store().data2() = jac * in.cov() * jac.adjoint();
     res.store().count() = in.count();
@@ -84,7 +84,7 @@ cov_result<T> transform(linear_prop p, const transformer<T> &tf, const InResult 
         dx = 0.125 * std::abs(in.stderror().mean());
     typename eigen<T>::matrix jac = jacobian(tf, in.mean(), dx);
 
-    cov_result<T> res(cov_data<T>(tf.out_size()));
+    cov_result<T> res(cov_data<T>(tf.out_size(), in.batch_size()));
     res.store().data() = tf(in.mean());
     res.store().data2() = jac * in.var().asDiagonal() * jac.adjoint();
     res.store().count() = in.count();

--- a/alea/include/alps/alea/variance.hpp
+++ b/alea/include/alps/alea/variance.hpp
@@ -23,6 +23,8 @@ namespace alps { namespace alea {
 
     template <typename T> class autocorr_acc;
     template <typename T> class autocorr_result;
+
+    template <typename T> class batch_result;
 }}
 
 // Actual declarations
@@ -164,6 +166,7 @@ private:
     bundle<value_type> current_;
 
     friend class autocorr_acc<T>;
+    friend class batch_result<T>;
 };
 
 template <typename T, typename Strategy>

--- a/alea/include/alps/alea/variance.hpp
+++ b/alea/include/alps/alea/variance.hpp
@@ -125,7 +125,7 @@ public:
     size_t batch_size() const { return current_.target(); }
 
     /** Add computed vector to the accumulator */
-    var_acc &operator<<(const computed<T> &src) { add(src, 1); return *this; }
+    var_acc &operator<<(const computed<T> &src) { add(src, 1, nullptr); return *this; }
 
     /** Add Eigen vector-valued expression to accumulator */
     template <typename Derived>
@@ -153,18 +153,15 @@ public:
     const var_data<T,Strategy> &store() const { return *store_; }
 
 protected:
-    void add(const computed<T> &source, size_t count);
+    void add(const computed<T> &source, size_t count, var_acc *cascade);
 
-    void add_bundle();
+    void add_bundle(var_acc *cascade);
 
-    void uplevel(var_acc &new_uplevel) { uplevel_ = &new_uplevel; }
-
-    void finalize_to(var_result<T,Strategy> &result);
+    void finalize_to(var_result<T,Strategy> &result, var_acc *cascade);
 
 private:
     std::unique_ptr< var_data<value_type, Strategy> > store_;
     bundle<value_type> current_;
-    var_acc *uplevel_;
 
     friend class autocorr_acc<T>;
 };

--- a/alea/include/alps/alea/variance.hpp
+++ b/alea/include/alps/alea/variance.hpp
@@ -45,7 +45,7 @@ public:
     typedef typename bind<Strategy, T>::var_type var_type;
 
 public:
-    var_data(size_t size);
+    var_data(size_t size, size_t batch_size);
 
     /** Re-allocate and thus clear all accumulated data */
     void reset();
@@ -58,6 +58,12 @@ public:
 
     /** Returns sample size, i.e., number of accumulated data points */
     size_t &count() { return count_; }
+
+    /** Returns number of data points per batch */
+    size_t batch_size() const { return batch_size_; }
+
+    /** Returns number of data points per batch */
+    size_t &batch_size() { return batch_size_; }
 
     const column<value_type> &data() const { return data_; }
 
@@ -74,7 +80,7 @@ public:
 private:
     column<T> data_;
     column<var_type> data2_;
-    size_t count_;
+    size_t count_, batch_size_;
 };
 
 template <typename T, typename Strategy>
@@ -114,6 +120,9 @@ public:
 
     /** Number of components of the random vector (e.g., size of mean) */
     size_t size() const { return current_.size(); }
+
+    /** Returns number of data points per batch */
+    size_t batch_size() const { return current_.target(); }
 
     /** Add computed vector to the accumulator */
     var_acc &operator<<(const computed<T> &src) { add(src, 1); return *this; }
@@ -199,6 +208,9 @@ public:
 
     /** Number of components of the random vector (e.g., size of mean) */
     size_t size() const { return store_->size(); }
+
+    /** Returns number of data points per batch */
+    size_t batch_size() const { return store_->batch_size(); }
 
     /** Returns sample size, i.e., number of accumulated data points */
     size_t count() const { return store_->count(); }

--- a/alea/include/alps/alea/variance.hpp
+++ b/alea/include/alps/alea/variance.hpp
@@ -116,7 +116,7 @@ public:
     size_t size() const { return current_.size(); }
 
     /** Add computed vector to the accumulator */
-    var_acc &operator<<(const computed<value_type> &source);
+    var_acc &operator<<(const computed<T> &src) { add(src, 1); return *this; }
 
     /** Add Eigen vector-valued expression to accumulator */
     template <typename Derived>
@@ -144,6 +144,8 @@ public:
     const var_data<T,Strategy> &store() const { return *store_; }
 
 protected:
+    void add(const computed<T> &source, size_t count);
+
     void add_bundle();
 
     void uplevel(var_acc &new_uplevel) { uplevel_ = &new_uplevel; }

--- a/alea/include/alps/alea/variance.hpp
+++ b/alea/include/alps/alea/variance.hpp
@@ -234,7 +234,7 @@ public:
     void reduce(const reducer &r) { reduce(r, true, true); }
 
     /** Convert result to a permanent format (write to disk etc.) */
-    void serialize(serializer &);
+    void serialize(serializer &) const;
 
 protected:
     void reduce(const reducer &, bool do_pre_commit, bool do_post_commit);

--- a/alea/src/autocorr.cpp
+++ b/alea/src/autocorr.cpp
@@ -38,18 +38,18 @@ void autocorr_acc<T>::add_level()
 }
 
 template <typename T>
-autocorr_acc<T> &autocorr_acc<T>::operator<<(const computed<T> &source)
+void autocorr_acc<T>::add(const computed<T> &source, size_t count)
 {
     assert(count_ < nextlevel_);
     internal::check_valid(*this);
 
     // if we require next level, then do it!
-    if(++count_ == nextlevel_)
+    count_ += count;
+    if(count_ == nextlevel_)
         add_level();
 
     // now add current element at the bottom and watch it propagate
     level_[0] << source;
-    return *this;
 }
 
 template <typename T>

--- a/alea/src/autocorr.cpp
+++ b/alea/src/autocorr.cpp
@@ -162,6 +162,22 @@ void autocorr_result<T>::reduce(const reducer &r, bool pre_commit, bool post_com
     }
 }
 
+template <typename T>
+void autocorr_result<T>::serialize(serializer &s) const
+{
+    internal::check_valid(*this);
+    s.write("count", make_adapter(count()));
+    s.write("mean/value", make_adapter(mean()));
+    s.write("mean/error", make_adapter(stderror()));
+
+    typename eigen<var_type>::matrix level_var(size(), nlevel());
+    for (size_t l = 0; l != nlevel(); ++l)
+        level_var.col(l) = level_[l].var();
+
+    typename eigen<var_type>::col_map var_map(level_var.data(), level_var.size());
+    s.write("levels/var/value", make_adapter(var_map));
+}
+
 template class autocorr_result<double>;
 template class autocorr_result<std::complex<double> >;
 

--- a/alea/src/autocorr.cpp
+++ b/alea/src/autocorr.cpp
@@ -106,7 +106,7 @@ size_t autocorr_result<T>::find_level(size_t min_samples) const
 template <typename T>
 column<typename autocorr_result<T>::var_type> autocorr_result<T>::var() const
 {
-    size_t lvl = find_level(default_min_samples);
+    size_t lvl = find_level(DEFAULT_MIN_SAMPLES);
 
     // The factor comes from the fact that we accumulate sums of batch_size
     // elements, and therefore we get this by the law of large numbers
@@ -116,7 +116,7 @@ column<typename autocorr_result<T>::var_type> autocorr_result<T>::var() const
 template <typename T>
 column<typename autocorr_result<T>::var_type> autocorr_result<T>::stderror() const
 {
-    size_t lvl = find_level(default_min_samples);
+    size_t lvl = find_level(DEFAULT_MIN_SAMPLES);
 
     // Standard error of the mean has another 1/N (but at the level!)
     double fact = 1. * batch_size(lvl) / level_[lvl].count();
@@ -126,7 +126,7 @@ column<typename autocorr_result<T>::var_type> autocorr_result<T>::stderror() con
 template <typename T>
 column<typename autocorr_result<T>::var_type> autocorr_result<T>::tau() const
 {
-    size_t lvl = find_level(default_min_samples);
+    size_t lvl = find_level(DEFAULT_MIN_SAMPLES);
     const column<var_type> &var0 = level_[0].var();
     const column<var_type> &varn = level_[lvl].var();
 

--- a/alea/src/batch.cpp
+++ b/alea/src/batch.cpp
@@ -80,20 +80,18 @@ void batch_acc<T>::reset()
 }
 
 template <typename T>
-batch_acc<T> &batch_acc<T>::operator<<(const computed<T> &source)
+void batch_acc<T>::add(const computed<T> &source, size_t count)
 {
     internal::check_valid(*this);
 
     // batch is full, move the cursor.
     // Doing this before the addition ensures no empty batches.
-    if (store_->count()(cursor_.current()) == current_batch_size())
+    if (store_->count()(cursor_.current()) >= current_batch_size())
         next_batch();
 
     // Since Eigen matrix are column-major, we can just pass the pointer
     source.add_to(sink<T>(store_->batch().col(cursor_.current()).data(), size()));
-    store_->count()(cursor_.current()) += 1;
-
-    return *this;
+    store_->count()(cursor_.current()) += count;
 }
 
 template <typename T>

--- a/alea/src/batch.cpp
+++ b/alea/src/batch.cpp
@@ -166,11 +166,10 @@ template <typename Str>
 column<typename bind<Str,T>::var_type> batch_result<T>::var() const
 {
     var_acc<T, Str> aux_acc(store_->size());
-
-    // FIXME count
-    for (size_t i = 0; i != store_->num_batches(); ++i)
-        aux_acc << column<T>(store_->batch().col(i));
-
+    for (size_t i = 0; i != store_->num_batches(); ++i) {
+        aux_acc.add(make_adapter(store_->batch().col(i)), store_->count()(i),
+                    nullptr);
+    }
     return aux_acc.finalize().var();
 }
 
@@ -179,11 +178,8 @@ template <typename Str>
 column<typename bind<Str,T>::cov_type> batch_result<T>::cov() const
 {
     cov_acc<T, Str> aux_acc(store_->size());
-
-    // FIXME count
     for (size_t i = 0; i != store_->num_batches(); ++i)
-        aux_acc << column<T>(store_->batch().col(i));
-
+        aux_acc.add(make_adapter(store_->batch().col(i)), store_->count()(i));
     return aux_acc.finalize().cov();
 }
 

--- a/alea/src/covariance.cpp
+++ b/alea/src/covariance.cpp
@@ -179,6 +179,20 @@ void cov_result<T,Str>::reduce(const reducer &r, bool pre_commit, bool post_comm
     }
 }
 
+template <typename T, typename Str>
+void cov_result<T,Str>::serialize(serializer &s) const
+{
+    internal::check_valid(*this);
+    s.write("count", make_adapter(count()));
+    s.write("mean/value", make_adapter(mean()));
+    s.write("mean/error", make_adapter(stderror()));
+
+    // FIXME: flattened
+    typename eigen<cov_type>::matrix cov_mat = cov();
+    typename eigen<cov_type>::col_map cov_map(cov_mat.data(), cov_mat.size());
+    s.write("cov/value", make_adapter(cov_map));
+}
+
 template class cov_result<double>;
 template class cov_result<std::complex<double>, circular_var>;
 template class cov_result<std::complex<double>, elliptic_var>;

--- a/alea/src/covariance.cpp
+++ b/alea/src/covariance.cpp
@@ -26,13 +26,13 @@ void cov_data<T,Str>::convert_to_mean()
 {
     data_ /= count_;
     data2_ -= count_ * internal::outer<bind<Str, T> >(data_, data_);
-    data2_ *= internal::make_eigen_scalar(1/(count_ - 1.0));
+    data2_ = data2_ / (count_ - 1.0);
 }
 
 template <typename T, typename Str>
 void cov_data<T,Str>::convert_to_sum()
 {
-    data2_ *= internal::make_eigen_scalar(count_ - 1.0);
+    data2_ = data2_ * (count_ - 1.0);
     data2_ += count_ * internal::outer<bind<Str, T> >(data_, data_);
     data_ *= count_;
 }

--- a/alea/src/covariance.cpp
+++ b/alea/src/covariance.cpp
@@ -26,13 +26,13 @@ void cov_data<T,Str>::convert_to_mean()
 {
     data_ /= count_;
     data2_ -= count_ * internal::outer<bind<Str, T> >(data_, data_);
-    data2_ /= count_ - 1;
+    data2_ *= internal::make_eigen_scalar(1/(count_ - 1.0));
 }
 
 template <typename T, typename Str>
 void cov_data<T,Str>::convert_to_sum()
 {
-    data2_ *= count_ - 1;
+    data2_ *= internal::make_eigen_scalar(count_ - 1.0);
     data2_ += count_ * internal::outer<bind<Str, T> >(data_, data_);
     data_ *= count_;
 }

--- a/alea/src/covariance.cpp
+++ b/alea/src/covariance.cpp
@@ -76,15 +76,14 @@ void cov_acc<T,Str>::reset()
 }
 
 template <typename T, typename Str>
-cov_acc<T,Str> &cov_acc<T,Str>::operator<<(const computed<value_type> &source)
+void cov_acc<T,Str>::add(const computed<value_type> &source, size_t count)
 {
     internal::check_valid(*this);
     source.add_to(sink<T>(current_.sum().data(), current_.size()));
-    ++current_.count();
+    current_.count() += count;
 
     if (current_.is_full())
         add_bundle();
-    return *this;
 }
 
 template <typename T, typename Str>

--- a/alea/src/covariance.cpp
+++ b/alea/src/covariance.cpp
@@ -117,15 +117,14 @@ template <typename T, typename Str>
 void cov_acc<T,Str>::add_bundle()
 {
     // add batch to average and squared
-    current_.sum() /= current_.count();
     store_->data().noalias() += current_.sum();
     store_->data2().noalias() +=
                 internal::outer<bind<Str, T> >(current_.sum(), current_.sum());
-    store_->count() += 1;
+    store_->count() += current_.count();
 
     // add batch mean also to uplevel
     if (uplevel_ != nullptr)
-        (*uplevel_) << current_.sum();
+        uplevel_->add(make_adapter(current_.sum()), current_.count());
 
     current_.reset();
 }

--- a/alea/src/covariance.cpp
+++ b/alea/src/covariance.cpp
@@ -5,9 +5,10 @@
 namespace alps { namespace alea {
 
 template <typename T, typename Str>
-cov_data<T,Str>::cov_data(size_t size)
+cov_data<T,Str>::cov_data(size_t size, size_t batch_size)
     : data_(size)
     , data2_(size, size)
+    , batch_size_(batch_size)
 {
     reset();
 }
@@ -43,7 +44,7 @@ template class cov_data<std::complex<double>, elliptic_var>;
 
 template <typename T, typename Str>
 cov_acc<T,Str>::cov_acc(size_t size, size_t bundle_size)
-    : store_(new cov_data<T,Str>(size))
+    : store_(new cov_data<T,Str>(size, bundle_size))
     , current_(size, bundle_size)
     , uplevel_(nullptr)
 { }
@@ -72,7 +73,7 @@ void cov_acc<T,Str>::reset()
     if (valid())
         store_->reset();
     else
-        store_.reset(new cov_data<T,Str>(size()));
+        store_.reset(new cov_data<T,Str>(size(), batch_size()));
 }
 
 template <typename T, typename Str>

--- a/alea/src/mean.cpp
+++ b/alea/src/mean.cpp
@@ -45,12 +45,11 @@ mean_acc<T> &mean_acc<T>::operator=(const mean_acc &other)
 }
 
 template <typename T>
-mean_acc<T> &mean_acc<T>::operator<<(const computed<T> &source)
+void mean_acc<T>::add(const computed<T> &source, size_t count)
 {
     internal::check_valid(*this);
     source.add_to(sink<T>(store_->data().data(), size()));
-    store_->count() += 1.0;
-    return *this;
+    store_->count() += count;
 }
 
 template <typename T>

--- a/alea/src/mean.cpp
+++ b/alea/src/mean.cpp
@@ -125,8 +125,15 @@ void mean_result<T>::reduce(const reducer &r, bool pre_commit, bool post_commit)
     }
 }
 
+template <typename T>
+void mean_result<T>::serialize(serializer &s) const
+{
+    internal::check_valid(*this);
+    s.write("count", make_adapter(count()));
+    s.write("mean/value", make_adapter(mean()));
+}
+
 template class mean_result<double>;
 template class mean_result<std::complex<double> >;
-
 
 }} /* namespace alps::alea */

--- a/alea/src/variance.cpp
+++ b/alea/src/variance.cpp
@@ -27,13 +27,13 @@ void var_data<T,Str>::convert_to_mean()
 {
     data_ /= count_;
     data2_ -= count_ * data_.cwiseAbs2();
-    data2_ /= count_ - 1;
+    data2_ *= internal::make_eigen_scalar(1/(count_ - 1.0));
 }
 
 template <typename T, typename Str>
 void var_data<T,Str>::convert_to_sum()
 {
-    data2_ *= count_ - 1;
+    data2_ *= internal::make_eigen_scalar(count_ - 1.0);
     data2_ += count_ * data_.cwiseAbs2();
     data_ *= count_;
 }

--- a/alea/src/variance.cpp
+++ b/alea/src/variance.cpp
@@ -6,9 +6,10 @@
 namespace alps { namespace alea {
 
 template <typename T, typename Str>
-var_data<T,Str>::var_data(size_t size)
+var_data<T,Str>::var_data(size_t size, size_t batch_size)
     : data_(size)
     , data2_(size)
+    , batch_size_(batch_size)
 {
     reset();
 }
@@ -44,7 +45,7 @@ template class var_data<std::complex<double>, elliptic_var>;
 
 template <typename T, typename Str>
 var_acc<T,Str>::var_acc(size_t size, size_t bundle_size)
-    : store_(new var_data<T,Str>(size))
+    : store_(new var_data<T,Str>(size, bundle_size))
     , current_(size, bundle_size)
     , uplevel_(nullptr)
 { }
@@ -73,7 +74,7 @@ void var_acc<T,Str>::reset()
     if (valid())
         store_->reset();
     else
-        store_.reset(new var_data<T,Str>(size()));
+        store_.reset(new var_data<T,Str>(size(), batch_size()));
 }
 
 template <typename T, typename Str>

--- a/alea/src/variance.cpp
+++ b/alea/src/variance.cpp
@@ -184,6 +184,14 @@ void var_result<T,Str>::reduce(const reducer &r, bool pre_commit, bool post_comm
     }
 }
 
+template <typename T, typename Str>
+void var_result<T,Str>::serialize(serializer &s) const
+{
+    internal::check_valid(*this);
+    s.write("count", make_adapter(count()));
+    s.write("mean/value", make_adapter(mean()));
+    s.write("mean/error", make_adapter(stderror()));
+}
 
 template class var_result<double>;
 template class var_result<std::complex<double>, circular_var>;

--- a/alea/src/variance.cpp
+++ b/alea/src/variance.cpp
@@ -77,15 +77,14 @@ void var_acc<T,Str>::reset()
 }
 
 template <typename T, typename Str>
-var_acc<T,Str> &var_acc<T,Str>::operator<<(const computed<value_type> &source)
+void var_acc<T,Str>::add(const computed<T> &source, size_t count)
 {
     internal::check_valid(*this);
     source.add_to(sink<T>(current_.sum().data(), current_.size()));
-    ++current_.count();
+    current_.count() += count;
 
     if (current_.is_full())
         add_bundle();
-    return *this;
 }
 
 template <typename T, typename Str>

--- a/alea/src/variance.cpp
+++ b/alea/src/variance.cpp
@@ -27,13 +27,13 @@ void var_data<T,Str>::convert_to_mean()
 {
     data_ /= count_;
     data2_ -= count_ * data_.cwiseAbs2();
-    data2_ *= internal::make_eigen_scalar(1/(count_ - 1.0));
+    data2_ = data2_ / (count_ - 1.0);
 }
 
 template <typename T, typename Str>
 void var_data<T,Str>::convert_to_sum()
 {
-    data2_ *= internal::make_eigen_scalar(count_ - 1.0);
+    data2_ = data2_ * (count_ - 1.0);
     data2_ += count_ * data_.cwiseAbs2();
     data_ *= count_;
 }

--- a/alea/src/variance.cpp
+++ b/alea/src/variance.cpp
@@ -120,14 +120,13 @@ void var_acc<T,Str>::add_bundle()
     typename bind<Str, T>::abs2_op abs2;
 
     // add batch to average and squared
-    current_.sum() /= current_.count();
     store_->data().noalias() += current_.sum();
     store_->data2().noalias() += current_.sum().unaryExpr(abs2);
-    store_->count() += 1;
+    store_->count() += current_.count();
 
     // add batch mean also to uplevel
     if (uplevel_ != nullptr)
-        (*uplevel_) << current_.sum();
+        uplevel_->add(make_adapter(current_.sum()), current_.count());
 
     current_.reset();
 }

--- a/alea/test/twogauss.cpp
+++ b/alea/test/twogauss.cpp
@@ -4,6 +4,8 @@
 #include <alps/alea/autocorr.hpp>
 #include <alps/alea/batch.hpp>
 
+#include <alps/alea/hdf5.hpp>
+
 #include "gtest/gtest.h"
 #include "dataset.hpp"
 
@@ -84,6 +86,14 @@ public:
         this->fill();
         test_result();    // keeps mean constant
     }
+
+    void test_serialize()
+    {
+        alps::hdf5::archive ar("twogauss.hdf5", "w");
+        alps::alea::hdf5_serializer ser(ar, "");
+        result_type res = this->acc().finalize();
+        res.serialize(ser);
+    }
 };
 
 typedef ::testing::Types<
@@ -101,6 +111,8 @@ TYPED_TEST(twogauss_mean_case, test_result) { this->test_result(); }
 TYPED_TEST(twogauss_mean_case, test_finalize) { this->test_finalize(); }
 
 TYPED_TEST(twogauss_mean_case, test_lifecycle) { this->test_lifecycle(); }
+
+TYPED_TEST(twogauss_mean_case, test_serialize) { this->test_serialize(); }
 
 // VARIANCE
 


### PR DESCRIPTION
Now we have basically all the features of the old code in place.

This fixes a couple of bugs:
 - no possiblity for serialization of a result
 - discarded left-over result in `var_acc` etc.
 - wrong variances, covariances in `batch_acc`