### PR TITLE
Quiet doxygen warnings:

### DIFF
--- a/common/doc/Doxyfile.in
+++ b/common/doc/Doxyfile.in
@@ -1057,7 +1057,8 @@ VERBATIM_HEADERS       = YES
 # generated with the -Duse-libclang=ON option for CMake.
 # The default value is: NO.
 
-CLANG_ASSISTED_PARSING = NO
+# To avoid warning
+# CLANG_ASSISTED_PARSING = NO
 
 # If clang assisted parsing is enabled you can provide the compiler with command
 # line options that you would normally use when invoking the compiler. Note that
@@ -1065,7 +1066,8 @@ CLANG_ASSISTED_PARSING = NO
 # specified with INPUT and INCLUDE_PATH.
 # This tag requires that the tag CLANG_ASSISTED_PARSING is set to YES.
 
-CLANG_OPTIONS          =
+# To avoid warning
+# CLANG_OPTIONS          =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index


### PR DESCRIPTION
Removes these warnings:

    warning: Tag `CLANG_ASSISTED_PARSING' at line 1060 of file ...

    warning: Tag `CLANG_OPTIONS' at line 1068 of file ...