### PR TITLE
Workaround for Intel C++ 2017

### DIFF
--- a/utilities/include/alps/testing/near.hpp
+++ b/utilities/include/alps/testing/near.hpp
@@ -24,7 +24,7 @@ template <> struct is_scalar<long double> : public std::true_type { };
 
 /** Helper function for implementing ALPS_EXPECT_NEAR. */
 template <typename T,
-          typename std::enable_if<is_scalar<T>::value>::type * = 0>
+          typename std::enable_if<is_scalar<T>::value,int>::type = 0>
 ::testing::AssertionResult NearPredFormat(const char* expr1,
                                           const char* expr2,
                                           const char* abs_error_expr,


### PR DESCRIPTION
Hi, I got the following compilation error with Intel C++ 17.0.4.196.
There seems to be a bug in the compiler.
I've written a quick workaround. 
Could you review it?

```
In file included from /home/i0412/i041200/git/ALPSCore/alea/test/transform.cpp(9):
/home/i0412/i041200/git/ALPSCore/utilities/include/alps/testing/near.hpp(27): error #501: argument of type "int" is incompatible with template parameter of type "std::enable_if<alps::testing::is_scalar<T>::value, void>::type *"
            typename std::enable_if<is_scalar<T>::value>::type * = 0>
                                                                   ^

compilation aborted for /home/i0412/i041200/git/ALPSCore/alea/test/transform.cpp (code 2)
```