### PR TITLE
[alea] Serialization bug fixes

### DIFF
--- a/alea/include/alps/alea/autocorr.hpp
+++ b/alea/include/alps/alea/autocorr.hpp
@@ -18,6 +18,9 @@ namespace alps { namespace alea {
     template <typename T> class autocorr_result;
 
     template <typename T> class batch_result;
+
+    template <typename T>
+    void serialize(serializer &, const autocorr_result<T> &);
 }}
 
 // Actual declarations
@@ -169,7 +172,7 @@ public:
     void reduce(const reducer &r) { reduce(r, true, true); }
 
     /** Convert result to a permanent format (write to disk etc.) */
-    void serialize(serializer &) const;
+    friend void serialize<>(serializer &, const autocorr_result &);
 
     size_t find_level(size_t min_samples) const;
 

--- a/alea/include/alps/alea/batch.hpp
+++ b/alea/include/alps/alea/batch.hpp
@@ -19,6 +19,9 @@ namespace alps { namespace alea {
     template <typename T> class batch_acc;
     template <typename T> class batch_data;
     template <typename T> class batch_result;
+
+    template <typename T>
+    void serialize(serializer &, const batch_result<T> &);
 }}
 
 // Actual declarations
@@ -202,7 +205,7 @@ public:
     void reduce(const reducer &r) { reduce(r, true, true); }
 
     /** Convert result to a permanent format (write to disk etc.) */
-    void serialize(serializer &) const;
+    friend void serialize<>(serializer &, const batch_result &);
 
 protected:
     void reduce(const reducer &r, bool do_pre_commit, bool do_post_commit);
@@ -229,4 +232,4 @@ struct traits< batch_result<T> >
 extern template class batch_result<double>;
 extern template class batch_result<std::complex<double> >;
 
-}}
+}} /* namespace alps::alea */

--- a/alea/include/alps/alea/covariance.hpp
+++ b/alea/include/alps/alea/covariance.hpp
@@ -22,6 +22,9 @@ namespace alps { namespace alea {
     template <typename T, typename Str> class cov_result;
 
     template <typename T> class batch_result;
+
+    template <typename T, typename Str>
+    void serialize(serializer &, const cov_result<T,Str> &);
 }}
 
 // Actual declarations
@@ -244,7 +247,7 @@ public:
     void reduce(const reducer &r) { reduce(r, true, true); }
 
     /** Convert result to a permanent format (write to disk etc.) */
-    void serialize(serializer &) const;
+    friend void serialize<>(serializer &, const cov_result &);
 
 protected:
     void reduce(const reducer &, bool do_pre_commit, bool do_post_commit);
@@ -261,6 +264,7 @@ struct traits< cov_result<T,Strategy> >
     typedef Strategy strategy_type;
     typedef typename bind<Strategy, T>::value_type value_type;
     typedef typename bind<Strategy, T>::var_type var_type;
+    typedef typename bind<Strategy, T>::cov_type cov_type;
 
     const static bool HAVE_MEAN  = true;
     const static bool HAVE_VAR   = true;
@@ -273,5 +277,4 @@ extern template class cov_result<double>;
 extern template class cov_result<std::complex<double>, circular_var>;
 extern template class cov_result<std::complex<double>, elliptic_var>;
 
-
-}}
+}} /* namespace alps::alea */

--- a/alea/include/alps/alea/hdf5.hpp
+++ b/alea/include/alps/alea/hdf5.hpp
@@ -16,7 +16,7 @@ namespace alps { namespace alea {
 
 inline std::string join_paths(const std::string &base, const std::string &rel)
 {
-    std::ostringstream maker(base);
+    std::ostringstream maker(base, std::ios_base::ate);
     if (*(base.rbegin()) != '/')
         maker << '/';
     if (*(rel.begin()) == '/')

--- a/alea/include/alps/alea/mean.hpp
+++ b/alea/include/alps/alea/mean.hpp
@@ -17,6 +17,9 @@ namespace alps { namespace alea {
     template <typename T> class mean_data;
     template <typename T> class mean_acc;
     template <typename T> class mean_result;
+
+    template <typename T>
+    void serialize(serializer &, const mean_result<T> &);
 }}
 
 // Actual declarations
@@ -184,7 +187,7 @@ public:
     void reduce(const reducer &r) { return reduce(r, true, true); }
 
     /** Convert result to a permanent format (write to disk etc.) */
-    void serialize(serializer &) const;
+    friend void serialize<>(serializer &, const mean_result &);
 
 protected:
     void reduce(const reducer &, bool do_pre_commit, bool do_post_commit);

--- a/alea/include/alps/alea/result.hpp
+++ b/alea/include/alps/alea/result.hpp
@@ -15,6 +15,14 @@
 
 namespace alps { namespace alea {
 
+class result;
+void serialize(serializer &, const result &);
+
+}}
+
+
+namespace alps { namespace alea {
+
 struct estimate_unavailable : public std::exception { };
 
 struct estimate_type_mismatch : public std::exception { };
@@ -56,6 +64,9 @@ public:
     /** Returns bias-corrected sample covariance matrix for given strategy */
     template <typename T, typename Str=circular_var>
     typename eigen<typename bind<Str,T>::cov_type>::matrix cov() const;
+
+    /** Convert result to a permanent format (write to disk etc.) */
+    friend void serialize(serializer &, const result &);
 
 private:
     typedef boost::variant<

--- a/alea/include/alps/alea/variance.hpp
+++ b/alea/include/alps/alea/variance.hpp
@@ -25,6 +25,9 @@ namespace alps { namespace alea {
     template <typename T> class autocorr_result;
 
     template <typename T> class batch_result;
+
+    template <typename T, typename Str>
+    void serialize(serializer &, const var_result<T,Str> &);
 }}
 
 // Actual declarations
@@ -237,7 +240,7 @@ public:
     void reduce(const reducer &r) { reduce(r, true, true); }
 
     /** Convert result to a permanent format (write to disk etc.) */
-    void serialize(serializer &) const;
+    friend void serialize<>(serializer &, const var_result &);
 
 protected:
     void reduce(const reducer &, bool do_pre_commit, bool do_post_commit);

--- a/alea/src/autocorr.cpp
+++ b/alea/src/autocorr.cpp
@@ -163,24 +163,30 @@ void autocorr_result<T>::reduce(const reducer &r, bool pre_commit, bool post_com
     }
 }
 
+template class autocorr_result<double>;
+template class autocorr_result<std::complex<double> >;
+
+
 template <typename T>
-void autocorr_result<T>::serialize(serializer &s) const
+void serialize(serializer &s, const autocorr_result<T> &self)
 {
-    internal::check_valid(*this);
-    s.write("count", make_adapter(count()));
-    s.write("mean/value", make_adapter(mean()));
-    s.write("mean/error", make_adapter(stderror()));
+    internal::check_valid(self);
+    s.write("count", make_adapter(self.count()));
+    s.write("mean/value", make_adapter(self.mean()));
+    s.write("mean/error", make_adapter(self.stderror()));
 
-    typename eigen<var_type>::matrix level_var(size(), nlevel());
-    for (size_t l = 0; l != nlevel(); ++l)
-        level_var.col(l) = level_[l].var();
+    typedef typename traits<autocorr_result<T>>::var_type var_type;
+    typename eigen<var_type>::matrix level_var(self.size(), self.nlevel());
+    for (size_t l = 0; l != self.nlevel(); ++l)
+        level_var.col(l) = self.level_[l].var();
 
+    // FIXME flattened
     typename eigen<var_type>::col_map var_map(level_var.data(), level_var.size());
     s.write("levels/var/value", make_adapter(var_map));
 }
 
-template class autocorr_result<double>;
-template class autocorr_result<std::complex<double> >;
+template void serialize(serializer &, const autocorr_result<double> &);
+template void serialize(serializer &, const autocorr_result<std::complex<double>> &);
 
 }}
 

--- a/alea/src/batch.cpp
+++ b/alea/src/batch.cpp
@@ -212,20 +212,6 @@ void batch_result<T>::reduce(const reducer &r, bool pre_commit, bool post_commit
     }
 }
 
-template <typename T>
-void batch_result<T>::serialize(serializer &s) const
-{
-    internal::check_valid(*this);
-    s.write("count", make_adapter(count()));
-    s.write("mean/value", make_adapter(mean()));
-    s.write("mean/error", make_adapter(stderror()));
-
-    // FIXME
-    typename eigen<T>::col_map batch_map(store_->batch().data(), store_->batch().size());
-    s.write("batch/count", make_adapter(store_->count().transpose()));
-    s.write("batch/sum", make_adapter(batch_map));
-}
-
 template column<double> batch_result<double>::var<circular_var>() const;
 template column<double> batch_result<std::complex<double> >::var<circular_var>() const;
 template column<complex_op<double> > batch_result<std::complex<double> >::var<elliptic_var>() const;
@@ -237,4 +223,22 @@ template column<complex_op<double> > batch_result<std::complex<double> >::cov<el
 template class batch_result<double>;
 template class batch_result<std::complex<double> >;
 
-}}
+
+template <typename T>
+void serialize(serializer &s, const batch_result<T> &self)
+{
+    internal::check_valid(self);
+    s.write("count", make_adapter(self.count()));
+    s.write("mean/value", make_adapter(self.mean()));
+    s.write("mean/error", make_adapter(self.stderror()));
+
+    // FIXME flattened
+    typename eigen<T>::col_map batch_map(self.store_->batch().data(), self.store_->batch().size());
+    s.write("batch/count", make_adapter(self.store_->count().transpose()));
+    s.write("batch/sum", make_adapter(batch_map));
+}
+
+template void serialize(serializer &, const batch_result<double> &);
+template void serialize(serializer &, const batch_result<std::complex<double>> &);
+
+}} /* namespace alps::alea */

--- a/alea/src/covariance.cpp
+++ b/alea/src/covariance.cpp
@@ -184,23 +184,29 @@ void cov_result<T,Str>::reduce(const reducer &r, bool pre_commit, bool post_comm
     }
 }
 
-template <typename T, typename Str>
-void cov_result<T,Str>::serialize(serializer &s) const
-{
-    internal::check_valid(*this);
-    s.write("count", make_adapter(count()));
-    s.write("obs", make_adapter(observations()));
-    s.write("mean/value", make_adapter(mean()));
-    s.write("mean/error", make_adapter(stderror()));
-
-    // FIXME: flattened
-    typename eigen<cov_type>::matrix cov_mat = cov();
-    typename eigen<cov_type>::col_map cov_map(cov_mat.data(), cov_mat.size());
-    s.write("cov/value", make_adapter(cov_map));
-}
-
 template class cov_result<double>;
 template class cov_result<std::complex<double>, circular_var>;
 template class cov_result<std::complex<double>, elliptic_var>;
 
-}}
+
+template <typename T, typename Str>
+void serialize(serializer &s, const cov_result<T,Str> &self)
+{
+    internal::check_valid(self);
+    s.write("count", make_adapter(self.count()));
+    s.write("obs", make_adapter(self.observations()));
+    s.write("mean/value", make_adapter(self.mean()));
+    s.write("mean/error", make_adapter(self.stderror()));
+
+    // FIXME: flattened
+    typedef typename traits<cov_result<T,Str>>::cov_type cov_type;
+    typename eigen<cov_type>::matrix cov_mat = self.cov();
+    typename eigen<cov_type>::col_map cov_map(cov_mat.data(), cov_mat.size());
+    s.write("cov/value", make_adapter(cov_map));
+}
+
+template void serialize(serializer &, const cov_result<double, circular_var> &);
+template void serialize(serializer &, const cov_result<std::complex<double>, circular_var> &);
+template void serialize(serializer &, const cov_result<std::complex<double>, elliptic_var> &);
+
+}} /* namespace alps::alea */

--- a/alea/src/mean.cpp
+++ b/alea/src/mean.cpp
@@ -125,15 +125,19 @@ void mean_result<T>::reduce(const reducer &r, bool pre_commit, bool post_commit)
     }
 }
 
-template <typename T>
-void mean_result<T>::serialize(serializer &s) const
-{
-    internal::check_valid(*this);
-    s.write("count", make_adapter(count()));
-    s.write("mean/value", make_adapter(mean()));
-}
-
 template class mean_result<double>;
 template class mean_result<std::complex<double> >;
+
+
+template <typename T>
+void serialize(serializer &s, const mean_result<T> &self)
+{
+    internal::check_valid(self);
+    s.write("count", make_adapter(self.count()));
+    s.write("mean/value", make_adapter(self.mean()));
+}
+
+template void serialize(serializer &, const mean_result<double> &);
+template void serialize(serializer &, const mean_result<std::complex<double> > &);
 
 }} /* namespace alps::alea */

--- a/alea/src/result.cpp
+++ b/alea/src/result.cpp
@@ -82,11 +82,29 @@ struct cov_visitor
     result_type operator() (const var_result<T,Str> &) const { throw estimate_unavailable(); }
     result_type operator() (const cov_result<T,Str> &r) const { return r.cov(); }
     result_type operator() (const autocorr_result<T> &) const { throw estimate_unavailable(); }
-    result_type operator() (const batch_result<T> &r) const { r.template cov<Str>(); }
+    result_type operator() (const batch_result<T> &r) const { return r.template cov<Str>(); }
 
     // default case
     template <typename Res>
     result_type operator() (const Res &) const { throw estimate_type_mismatch(); }
+};
+
+struct serialize_visitor
+{
+    typedef bool result_type;
+
+    serialize_visitor(serializer &s) : s_(s) { }
+
+    // default case
+    template <typename Res>
+    bool operator() (const Res &res) const
+    {
+        serialize(s_, res);
+        return false;     // the visitor mechanism does not allow void returns
+    }
+
+private:
+    serializer &s_;
 };
 
 bool result::valid() const
@@ -127,5 +145,10 @@ typename eigen<typename bind<Str,T>::cov_type>::matrix result::cov() const
 template eigen<double>::matrix result::cov<double, circular_var>() const;
 template eigen<std::complex<double> >::matrix result::cov<std::complex<double>, circular_var>() const;
 template eigen<complex_op<double> >::matrix result::cov<std::complex<double>, elliptic_var>() const;
+
+void serialize(serializer &s, const result &result)
+{
+    boost::apply_visitor(serialize_visitor(s), result.res_);
+}
 
 }}

--- a/alea/src/variance.cpp
+++ b/alea/src/variance.cpp
@@ -188,18 +188,23 @@ void var_result<T,Str>::reduce(const reducer &r, bool pre_commit, bool post_comm
     }
 }
 
-template <typename T, typename Str>
-void var_result<T,Str>::serialize(serializer &s) const
-{
-    internal::check_valid(*this);
-    s.write("count", make_adapter(count()));
-    s.write("observations", make_adapter(observations()));
-    s.write("mean/value", make_adapter(mean()));
-    s.write("mean/error", make_adapter(stderror()));
-}
-
 template class var_result<double>;
 template class var_result<std::complex<double>, circular_var>;
 template class var_result<std::complex<double>, elliptic_var>;
+
+
+template <typename T, typename Str>
+void serialize(serializer &s, const var_result<T,Str> &self)
+{
+    internal::check_valid(self);
+    s.write("count", make_adapter(self.count()));
+    s.write("observations", make_adapter(self.observations()));
+    s.write("mean/value", make_adapter(self.mean()));
+    s.write("mean/error", make_adapter(self.stderror()));
+}
+
+template void serialize(serializer &, const var_result<double, circular_var> &);
+template void serialize(serializer &, const var_result<std::complex<double>, circular_var> &);
+template void serialize(serializer &, const var_result<std::complex<double>, elliptic_var> &);
 
 }}

--- a/alea/test/twogauss.cpp
+++ b/alea/test/twogauss.cpp
@@ -92,7 +92,7 @@ public:
         alps::hdf5::archive ar("twogauss.hdf5", "w");
         alps::alea::hdf5_serializer ser(ar, "");
         result_type res = this->acc().finalize();
-        res.serialize(ser);
+        alps::alea::serialize(ser, res);
     }
 };
 


### PR DESCRIPTION
@katherlee @krivenko : this directly affects you

Note that this is compatibility break -- you will have to replace:

     alps::alea::mean_result<T> res;
     alps::alea::hdf_serializer ser;
     // res.serialize(ser);  
     alps::alea::serialize(ser, res);

Fixes: #437
Fixes: #438 
