### PR TITLE
ALEA: stream_serializer, a result serialization plugin

### DIFF
--- a/alea/include/alps/alea/autocorr.hpp
+++ b/alea/include/alps/alea/autocorr.hpp
@@ -199,6 +199,10 @@ public:
 
     level_result_type &level(size_t i) { return level_[i]; }
 
+    /** Check if this result is identical to another */
+    bool operator==(const autocorr_result &other) const;
+    bool operator!=(const autocorr_result &other) const { return !operator==(other); }
+
 protected:
     void reduce(const reducer &r, bool do_pre_commit, bool do_post_commit);
 

--- a/alea/include/alps/alea/autocorr.hpp
+++ b/alea/include/alps/alea/autocorr.hpp
@@ -209,6 +209,8 @@ private:
     friend class autocorr_acc<T>;
 };
 
+template<typename T> struct is_alea_result<autocorr_result<T>> : std::true_type {};
+
 template <typename T>
 struct traits< autocorr_result<T> >
 {

--- a/alea/include/alps/alea/autocorr.hpp
+++ b/alea/include/alps/alea/autocorr.hpp
@@ -199,10 +199,6 @@ public:
 
     level_result_type &level(size_t i) { return level_[i]; }
 
-    /** Check if this result is identical to another */
-    bool operator==(const autocorr_result &other) const;
-    bool operator!=(const autocorr_result &other) const { return !operator==(other); }
-
 protected:
     void reduce(const reducer &r, bool do_pre_commit, bool do_post_commit);
 
@@ -212,6 +208,15 @@ private:
 
     friend class autocorr_acc<T>;
 };
+
+/** Check if two results are identical */
+template <typename T>
+bool operator==(const autocorr_result<T> &r1, const autocorr_result<T> &r2);
+template <typename T>
+bool operator!=(const autocorr_result<T> &r1, const autocorr_result<T> &r2)
+{
+    return !operator==(r1, r2);
+}
 
 template<typename T> struct is_alea_result<autocorr_result<T>> : std::true_type {};
 

--- a/alea/include/alps/alea/batch.hpp
+++ b/alea/include/alps/alea/batch.hpp
@@ -231,10 +231,6 @@ public:
     /** Write some info about the result to a stream */
     friend std::ostream &operator<< <>(std::ostream &, const batch_result &);
 
-    /** Check if this result is identical to another */
-    bool operator==(const batch_result &other) const;
-    bool operator!=(const batch_result &other) const { return !operator==(other); }
-
 protected:
     void reduce(const reducer &r, bool do_pre_commit, bool do_post_commit);
 
@@ -243,6 +239,15 @@ private:
 
     friend class batch_acc<T>;
 };
+
+/** Check if two results are identical */
+template <typename T>
+bool operator==(const batch_result<T> &r1, const batch_result<T> &r2);
+template <typename T>
+bool operator!=(const batch_result<T> &r1, const batch_result<T> &r2)
+{
+    return !operator==(r1, r2);
+}
 
 template<typename T> struct is_alea_result<batch_result<T>> : std::true_type {};
 

--- a/alea/include/alps/alea/batch.hpp
+++ b/alea/include/alps/alea/batch.hpp
@@ -231,6 +231,10 @@ public:
     /** Write some info about the result to a stream */
     friend std::ostream &operator<< <>(std::ostream &, const batch_result &);
 
+    /** Check if this result is identical to another */
+    bool operator==(const batch_result &other) const;
+    bool operator!=(const batch_result &other) const { return !operator==(other); }
+
 protected:
     void reduce(const reducer &r, bool do_pre_commit, bool do_post_commit);
 

--- a/alea/include/alps/alea/batch.hpp
+++ b/alea/include/alps/alea/batch.hpp
@@ -240,6 +240,8 @@ private:
     friend class batch_acc<T>;
 };
 
+template<typename T> struct is_alea_result<batch_result<T>> : std::true_type {};
+
 template <typename T>
 struct traits< batch_result<T> >
 {

--- a/alea/include/alps/alea/core.hpp
+++ b/alea/include/alps/alea/core.hpp
@@ -36,6 +36,9 @@ struct weight_mismatch : public std::exception { };
 template <typename T>
 struct traits;
 
+// Metafunction to detect ALEA result types
+template<typename T> struct is_alea_result : std::false_type {};
+
 /**
  * Data view as a thin wrapper around a continuous array.
  *

--- a/alea/include/alps/alea/covariance.hpp
+++ b/alea/include/alps/alea/covariance.hpp
@@ -276,10 +276,6 @@ public:
     /** Write some info about the result to a stream */
     friend std::ostream &operator<< <>(std::ostream &, const cov_result &);
 
-    /** Check if this result is identical to another */
-    bool operator==(const cov_result &other) const;
-    bool operator!=(const cov_result &other) const { return !operator==(other); }
-
 protected:
     void reduce(const reducer &, bool do_pre_commit, bool do_post_commit);
 
@@ -288,6 +284,15 @@ private:
 
     friend class cov_acc<T,Strategy>;
 };
+
+/** Check if two results are identical */
+template <typename T, typename Strategy>
+bool operator==(const cov_result<T, Strategy> &r1, const cov_result<T, Strategy> &r2);
+template <typename T, typename Strategy>
+bool operator!=(const cov_result<T, Strategy> &r1, const cov_result<T, Strategy> &r2)
+{
+    return !operator==(r1, r2);
+}
 
 template<typename T> struct is_alea_result<cov_result<T, circular_var>> :
     std::true_type {};

--- a/alea/include/alps/alea/covariance.hpp
+++ b/alea/include/alps/alea/covariance.hpp
@@ -276,6 +276,10 @@ public:
     /** Write some info about the result to a stream */
     friend std::ostream &operator<< <>(std::ostream &, const cov_result &);
 
+    /** Check if this result is identical to another */
+    bool operator==(const cov_result &other) const;
+    bool operator!=(const cov_result &other) const { return !operator==(other); }
+
 protected:
     void reduce(const reducer &, bool do_pre_commit, bool do_post_commit);
 

--- a/alea/include/alps/alea/covariance.hpp
+++ b/alea/include/alps/alea/covariance.hpp
@@ -285,6 +285,11 @@ private:
     friend class cov_acc<T,Strategy>;
 };
 
+template<typename T> struct is_alea_result<cov_result<T, circular_var>> :
+    std::true_type {};
+template<typename T> struct is_alea_result<cov_result<T, elliptic_var>> :
+    std::true_type {};
+
 template <typename T, typename Strategy>
 struct traits< cov_result<T,Strategy> >
 {

--- a/alea/include/alps/alea/mean.hpp
+++ b/alea/include/alps/alea/mean.hpp
@@ -209,10 +209,6 @@ public:
     /** Write some info about the result to a stream */
     friend std::ostream &operator<< <>(std::ostream &, const mean_result &);
 
-    /** Check if this result is identical to another */
-    bool operator==(const mean_result &other) const;
-    bool operator!=(const mean_result &other) const { return !operator==(other); }
-
 protected:
     void reduce(const reducer &, bool do_pre_commit, bool do_post_commit);
 
@@ -221,6 +217,15 @@ private:
 
     friend class mean_acc<T>;
 };
+
+/** Check if two results are identical */
+template <typename T>
+bool operator==(const mean_result<T> &r1, const mean_result<T> &r2);
+template <typename T>
+bool operator!=(const mean_result<T> &r1, const mean_result<T> &r2)
+{
+    return !operator==(r1, r2);
+}
 
 template<typename T> struct is_alea_result<mean_result<T>> : std::true_type {};
 

--- a/alea/include/alps/alea/mean.hpp
+++ b/alea/include/alps/alea/mean.hpp
@@ -218,6 +218,8 @@ private:
     friend class mean_acc<T>;
 };
 
+template<typename T> struct is_alea_result<mean_result<T>> : std::true_type {};
+
 template <typename T>
 struct traits< mean_result<T> >
 {

--- a/alea/include/alps/alea/mean.hpp
+++ b/alea/include/alps/alea/mean.hpp
@@ -203,11 +203,15 @@ public:
     /** Convert result to a permanent format (write to disk etc.) */
     friend void serialize<>(serializer &, const std::string &, const mean_result &);
 
-    /** Reresult to a permanent format (write to disk etc.) */
+    /** Result to a permanent format (write to disk etc.) */
     friend void deserialize<>(deserializer &, const std::string &, mean_result &);
 
     /** Write some info about the result to a stream */
     friend std::ostream &operator<< <>(std::ostream &, const mean_result &);
+
+    /** Check if this result is identical to another */
+    bool operator==(const mean_result &other) const;
+    bool operator!=(const mean_result &other) const { return !operator==(other); }
 
 protected:
     void reduce(const reducer &, bool do_pre_commit, bool do_post_commit);

--- a/alea/include/alps/alea/plugin/stream_serializer.hpp
+++ b/alea/include/alps/alea/plugin/stream_serializer.hpp
@@ -85,7 +85,7 @@ private:
 };
 
 /**
- * stream_serializer
+ * stream_deserializer
  *
  * This class establishes connection between the ALEA serialization
  * interface and Boost/HPX serialization frameworks. Its instance

--- a/alea/include/alps/alea/plugin/stream_serializer.hpp
+++ b/alea/include/alps/alea/plugin/stream_serializer.hpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 1998-2018 ALPS Collaboration. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ * For use in publications, see ACKNOWLEDGE.TXT
+ */
+#pragma once
+
+#include <numeric>
+#include <type_traits>
+
+#include <alps/alea/core.hpp>
+#include <alps/alea/complex_op.hpp>
+#include <alps/alea/mean.hpp>
+#include <alps/alea/variance.hpp>
+#include <alps/alea/covariance.hpp>
+#include <alps/alea/autocorr.hpp>
+#include <alps/alea/batch.hpp>
+
+namespace alps { namespace alea {
+
+/**
+ * stream_serializer
+ *
+ * This class establishes connection between the ALEA serialization
+ * interface and Boost/HPX serialization frameworks. Its instances
+ * are used in free functions save() and load() (see below) that are
+ * called upon Boost/HPX (de)serialization of ALEA *_result<T> types.
+ */
+template <typename Archive> class stream_serializer
+    : public serializer
+    , public deserializer
+{
+
+public:
+
+    stream_serializer(Archive &ar) : ar_(ar) {}
+
+    // Common methods
+
+    // Nothing to be done here: streams have no notion of groups
+    void enter(const std::string &) override {}
+    void exit() override {}
+
+    // Key names are irrelevant
+
+    void write(const std::string &, ndview<const double> data_view) override
+    {
+        do_write(data_view);
+    }
+    void write(const std::string &, ndview<const std::complex<double>> data_view) override
+    {
+        do_write(data_view);
+    }
+    void write(const std::string &, ndview<const complex_op<double>> data_view) override
+    {
+        do_write(data_view);
+    }
+    void write(const std::string &, ndview<const long> data_view) override
+    {
+        do_write(data_view);
+    }
+    void write(const std::string &, ndview<const unsigned long> data_view) override
+    {
+        do_write(data_view);
+    }
+
+    // Deserialization methods
+
+    std::vector<size_t> get_shape(const std::string &key) override
+    {
+        return {{}}; // There is no way to know the shape beforehand
+    }
+
+    void read(const std::string &, ndview<double> value) override
+    {
+        do_read(value);
+    }
+    void read(const std::string &, ndview<std::complex<double>> value) override
+    {
+        do_read(value);
+    }
+    void read(const std::string &, ndview<complex_op<double>> value) override
+    {
+        do_read(value);
+    }
+    void read(const std::string &, ndview<long> value) override
+    {
+        do_read(value);
+    }
+    void read(const std::string &, ndview<unsigned long> value) override
+    {
+        do_read(value);
+    }
+
+protected:
+
+    template <typename T> void do_write(const ndview<const T> &data_view)
+    {
+        const size_t * shape = data_view.shape();
+        size_t size = compute_size(shape, data_view.ndim());
+
+        const T * data = data_view.data();
+        for(long n = 0; n < size; ++n)
+            ar_ << *(data + n);
+    }
+
+    template <typename T> void do_read(ndview<T> &data_view)
+    {
+        const size_t * shape = data_view.shape();
+        size_t size = compute_size(shape, data_view.ndim());
+
+        T * data = data_view.data();
+        if(data) {
+            for(long n = 0; n < size; ++n)
+                ar_ >> *(data + n);
+        } else {
+            T tmp;
+            for(long n = 0; n < size; ++n)
+                ar_ >> tmp;
+        }
+    }
+
+    static size_t compute_size(const size_t *shape, size_t ndim)
+    {
+        return std::accumulate(shape, shape + ndim, 1, std::multiplies<size_t>());
+    }
+
+private:
+
+    Archive &ar_;
+};
+
+
+/**
+ * This method will be called by Boost/HPX Serialization libraries
+ * when serialization of an ALEA result type is requested.
+ */
+template <typename Archive, typename T>
+typename std::enable_if<is_alea_result<T>::value, void>::type
+save(Archive &ar, const T &r, const unsigned int) {
+    stream_serializer<Archive> ser(ar);
+    serialize(ser, "", r);
+}
+
+/**
+ * This method will be called by Boost/HPX Serialization libraries
+ * when deserialization of an ALEA result type is requested.
+ */
+template <typename Archive, typename T>
+typename std::enable_if<is_alea_result<T>::value, void>::type
+load(Archive &ar, T &r, const unsigned int) {
+    stream_serializer<Archive> ser(ar);
+    deserialize(ser, "", r);
+}
+
+/**
+ * Serialize/deserialize alps::alea::complex_op<T>.
+ * Called by Boost/HPX Serialization libraries.
+ */
+template <typename Archive, typename T>
+void serialize(Archive &ar, complex_op<T> &co, const unsigned int) {
+    ar & co.rere() & co.reim() & co.imre() & co.imim();
+}
+
+}}

--- a/alea/include/alps/alea/variance.hpp
+++ b/alea/include/alps/alea/variance.hpp
@@ -269,6 +269,10 @@ public:
     /** Write some info about the result to a stream */
     friend std::ostream &operator<< <>(std::ostream &, const var_result &);
 
+    /** Check if this result is identical to another */
+    bool operator==(const var_result &other) const;
+    bool operator!=(const var_result &other) const { return !operator==(other); }
+
 protected:
     void reduce(const reducer &, bool do_pre_commit, bool do_post_commit);
 

--- a/alea/include/alps/alea/variance.hpp
+++ b/alea/include/alps/alea/variance.hpp
@@ -279,6 +279,11 @@ private:
     friend class autocorr_result<T>;
 };
 
+template<typename T> struct is_alea_result<var_result<T, circular_var>> :
+    std::true_type {};
+template<typename T> struct is_alea_result<var_result<T, elliptic_var>> :
+    std::true_type {};
+
 template <typename T, typename Strategy>
 struct traits< var_result<T,Strategy> >
 {

--- a/alea/include/alps/alea/variance.hpp
+++ b/alea/include/alps/alea/variance.hpp
@@ -269,10 +269,6 @@ public:
     /** Write some info about the result to a stream */
     friend std::ostream &operator<< <>(std::ostream &, const var_result &);
 
-    /** Check if this result is identical to another */
-    bool operator==(const var_result &other) const;
-    bool operator!=(const var_result &other) const { return !operator==(other); }
-
 protected:
     void reduce(const reducer &, bool do_pre_commit, bool do_post_commit);
 
@@ -282,6 +278,15 @@ private:
     friend class var_acc<T,Strategy>;
     friend class autocorr_result<T>;
 };
+
+/** Check if two results are identical */
+template <typename T, typename Strategy>
+bool operator==(const var_result<T, Strategy> &r1, const var_result<T, Strategy> &r2);
+template <typename T, typename Strategy>
+bool operator!=(const var_result<T, Strategy> &r1, const var_result<T, Strategy> &r2)
+{
+    return !operator==(r1, r2);
+}
 
 template<typename T> struct is_alea_result<var_result<T, circular_var>> :
     std::true_type {};

--- a/alea/src/autocorr.cpp
+++ b/alea/src/autocorr.cpp
@@ -104,6 +104,16 @@ void autocorr_acc<T>::finalize_to(autocorr_result<T> &result)
 template class autocorr_acc<double>;
 template class autocorr_acc<std::complex<double> >;
 
+template <typename T>
+bool autocorr_result<T>::operator==(const autocorr_result &other) const
+{
+    if(nlevel() != other.nlevel()) return false;
+    for(size_t i = 0; i < nlevel(); ++i) {
+        if(level(i) != other.level(i))
+            return false;
+    }
+    return true;
+}
 
 template <typename T>
 size_t autocorr_result<T>::batch_size(size_t i) const

--- a/alea/src/autocorr.cpp
+++ b/alea/src/autocorr.cpp
@@ -223,7 +223,7 @@ void deserialize(deserializer &s, const std::string &key, autocorr_result<T> &se
 
     // first deserialize the fundamentals and make sure that the target fits
     size_t new_size = 1;
-    s.read("@size", ndview<size_t>(nullptr, &new_size, 1)); // discard
+    s.read("@size", ndview<size_t>(nullptr, &new_size, 0)); // discard
     size_t new_nlevel;
     deserialize(s, "@nlevel", new_nlevel);
     self.level_.resize(new_nlevel);

--- a/alea/src/autocorr.cpp
+++ b/alea/src/autocorr.cpp
@@ -105,15 +105,20 @@ template class autocorr_acc<double>;
 template class autocorr_acc<std::complex<double> >;
 
 template <typename T>
-bool autocorr_result<T>::operator==(const autocorr_result &other) const
+bool operator==(const autocorr_result<T> &r1, const autocorr_result<T> &r2)
 {
-    if(nlevel() != other.nlevel()) return false;
-    for(size_t i = 0; i < nlevel(); ++i) {
-        if(level(i) != other.level(i))
+    if(r1.nlevel() != r2.nlevel()) return false;
+    for(size_t i = 0; i < r1.nlevel(); ++i) {
+        if(r1.level(i) != r2.level(i))
             return false;
     }
     return true;
 }
+
+template bool operator==(const autocorr_result<double> &r1,
+                         const autocorr_result<double> &r2);
+template bool operator==(const autocorr_result<std::complex<double>> &r1,
+                         const autocorr_result<std::complex<double>> &r2);
 
 template <typename T>
 size_t autocorr_result<T>::batch_size(size_t i) const

--- a/alea/src/autocorr.cpp
+++ b/alea/src/autocorr.cpp
@@ -222,6 +222,8 @@ void deserialize(deserializer &s, const std::string &key, autocorr_result<T> &se
     internal::deserializer_sentry group(s, key);
 
     // first deserialize the fundamentals and make sure that the target fits
+    size_t new_size = 1;
+    s.read("@size", ndview<size_t>(nullptr, &new_size, 1)); // discard
     size_t new_nlevel;
     deserialize(s, "@nlevel", new_nlevel);
     self.level_.resize(new_nlevel);
@@ -232,7 +234,7 @@ void deserialize(deserializer &s, const std::string &key, autocorr_result<T> &se
     s.exit();
 
     s.enter("mean");
-    size_t new_size = self.size();
+    new_size = self.size();
     s.read("value", ndview<T>(nullptr, &new_size, 1)); // discard
     s.read("error", ndview<var_type>(nullptr, &new_size, 1)); // discard
     s.exit();

--- a/alea/src/batch.cpp
+++ b/alea/src/batch.cpp
@@ -175,11 +175,16 @@ batch_result<T> &batch_result<T>::operator=(const batch_result &other)
 }
 
 template <typename T>
-bool batch_result<T>::operator==(const batch_result &other) const
+bool operator==(const batch_result<T> &r1, const batch_result<T> &r2)
 {
-    return count() == other.count()
-        && store().batch() == other.store().batch();
+    return r1.count() == r2.count()
+        && r1.store().batch() == r2.store().batch();
 }
+
+template bool operator==(const batch_result<double> &r1,
+                         const batch_result<double> &r2);
+template bool operator==(const batch_result<std::complex<double>> &r1,
+                         const batch_result<std::complex<double>> &r2);
 
 template <typename T>
 column<T> batch_result<T>::mean() const

--- a/alea/src/batch.cpp
+++ b/alea/src/batch.cpp
@@ -175,6 +175,13 @@ batch_result<T> &batch_result<T>::operator=(const batch_result &other)
 }
 
 template <typename T>
+bool batch_result<T>::operator==(const batch_result &other) const
+{
+    return count() == other.count()
+        && store().batch() == other.store().batch();
+}
+
+template <typename T>
 column<T> batch_result<T>::mean() const
 {
     return store_->batch().rowwise().sum() / count();

--- a/alea/src/covariance.cpp
+++ b/alea/src/covariance.cpp
@@ -175,6 +175,15 @@ cov_result<T,Str> &cov_result<T,Str>::operator=(const cov_result &other)
     return *this;
 }
 
+template <typename T, typename Strategy>
+bool cov_result<T,Strategy>::operator==(const cov_result &other) const
+{
+    return count() == other.count()
+        && count2() == other.count2()
+        && store().data() == other.store().data()
+        && store().data2() == other.store().data2();
+}
+
 template <typename T, typename Str>
 column<typename cov_result<T,Str>::var_type> cov_result<T,Str>::stderror() const
 {

--- a/alea/src/covariance.cpp
+++ b/alea/src/covariance.cpp
@@ -176,13 +176,19 @@ cov_result<T,Str> &cov_result<T,Str>::operator=(const cov_result &other)
 }
 
 template <typename T, typename Strategy>
-bool cov_result<T,Strategy>::operator==(const cov_result &other) const
+bool operator==(const cov_result<T,Strategy> &r1, const cov_result<T,Strategy> &r2)
 {
-    return count() == other.count()
-        && count2() == other.count2()
-        && store().data() == other.store().data()
-        && store().data2() == other.store().data2();
+    return r1.count() == r2.count()
+        && r1.count2() == r2.count2()
+        && r1.store().data() == r2.store().data()
+        && r1.store().data2() == r2.store().data2();
 }
+
+template bool operator==(const cov_result<double> &r1, const cov_result<double> &r2);
+template bool operator==(const cov_result<std::complex<double>, circular_var> &r1,
+                         const cov_result<std::complex<double>, circular_var> &r2);
+template bool operator==(const cov_result<std::complex<double>, elliptic_var> &r1,
+                         const cov_result<std::complex<double>, elliptic_var> &r2);
 
 template <typename T, typename Str>
 column<typename cov_result<T,Str>::var_type> cov_result<T,Str>::stderror() const

--- a/alea/src/mean.cpp
+++ b/alea/src/mean.cpp
@@ -123,6 +123,12 @@ mean_result<T> &mean_result<T>::operator=(const mean_result &other)
 }
 
 template <typename T>
+bool mean_result<T>::operator==(const mean_result &other) const {
+    return count() == other.count()
+        && store().data() == other.store().data();
+}
+
+template <typename T>
 void mean_result<T>::reduce(const reducer &r, bool pre_commit, bool post_commit)
 {
     internal::check_valid(*this);

--- a/alea/src/mean.cpp
+++ b/alea/src/mean.cpp
@@ -123,10 +123,16 @@ mean_result<T> &mean_result<T>::operator=(const mean_result &other)
 }
 
 template <typename T>
-bool mean_result<T>::operator==(const mean_result &other) const {
-    return count() == other.count()
-        && store().data() == other.store().data();
+bool operator==(const mean_result<T> &r1, const mean_result<T> &r2)
+{
+    return r1.count() == r2.count()
+        && r1.store().data() == r2.store().data();
 }
+
+template bool operator==(const mean_result<double> &r1,
+                         const mean_result<double> &r2);
+template bool operator==(const mean_result<std::complex<double>> &r1,
+                         const mean_result<std::complex<double>> &r2);
 
 template <typename T>
 void mean_result<T>::reduce(const reducer &r, bool pre_commit, bool post_commit)

--- a/alea/src/variance.cpp
+++ b/alea/src/variance.cpp
@@ -179,6 +179,15 @@ var_result<T,Str> &var_result<T,Str>::operator=(const var_result &other)
     return *this;
 }
 
+template <typename T, typename Strategy>
+bool var_result<T,Strategy>::operator==(const var_result &other) const
+{
+    return count() == other.count()
+        && count2() == other.count2()
+        && store().data() == other.store().data()
+        && store().data2() == other.store().data2();
+}
+
 template <typename T, typename Str>
 column<typename var_result<T,Str>::var_type> var_result<T,Str>::stderror() const
 {

--- a/alea/src/variance.cpp
+++ b/alea/src/variance.cpp
@@ -180,13 +180,19 @@ var_result<T,Str> &var_result<T,Str>::operator=(const var_result &other)
 }
 
 template <typename T, typename Strategy>
-bool var_result<T,Strategy>::operator==(const var_result &other) const
+bool operator==(const var_result<T, Strategy> &r1, const var_result<T, Strategy> &r2)
 {
-    return count() == other.count()
-        && count2() == other.count2()
-        && store().data() == other.store().data()
-        && store().data2() == other.store().data2();
+    return r1.count() == r2.count()
+        && r1.count2() == r2.count2()
+        && r1.store().data() == r2.store().data()
+        && r1.store().data2() == r2.store().data2();
 }
+
+template bool operator==(const var_result<double> &r1, const var_result<double> &r2);
+template bool operator==(const var_result<std::complex<double>, circular_var> &r1,
+                         const var_result<std::complex<double>, circular_var> &r2);
+template bool operator==(const var_result<std::complex<double>, elliptic_var> &r1,
+                         const var_result<std::complex<double>, elliptic_var> &r2);
 
 template <typename T, typename Str>
 column<typename var_result<T,Str>::var_type> var_result<T,Str>::stderror() const

--- a/alea/test/CMakeLists.txt
+++ b/alea/test/CMakeLists.txt
@@ -4,6 +4,7 @@ set (test_src
      twogauss
      galois
      transform
+     stream_serializer
     )
 
 #add tests for MPI

--- a/alea/test/stream_serializer.cpp
+++ b/alea/test/stream_serializer.cpp
@@ -49,6 +49,7 @@ public:
       extract_fundamental(r);
       extract_fundamental(i);
       x = std::complex<double>(r, i);
+      return *this;
     }
 
     // Extract complex_op<T>

--- a/alea/test/stream_serializer.cpp
+++ b/alea/test/stream_serializer.cpp
@@ -74,14 +74,14 @@ private:
     template<typename T>
     void store_fundamental(T x) {
         unsigned char* p = reinterpret_cast<unsigned char*>(&x);
-        for(int n = 0; n < sizeof(T); ++n)
+        for(size_t n = 0; n < sizeof(T); ++n)
             buf.push(*(p + n));
     }
 
     template<typename T>
     void extract_fundamental(T &x) {
         unsigned char* p = reinterpret_cast<unsigned char*>(&x);
-        for(int n = 0; n < sizeof(T); ++n) {
+        for(size_t n = 0; n < sizeof(T); ++n) {
             *(p + n) = buf.front();
             buf.pop();
         }

--- a/alea/test/stream_serializer.cpp
+++ b/alea/test/stream_serializer.cpp
@@ -7,17 +7,17 @@
 #include <queue>
 
 // Mock class that emulates Boost/HPX serialization archive
-class MockArchive {
+class mock_archive {
 
 public:
 
-    MockArchive() {}
+    mock_archive() {}
 
     // Store simple types
-    MockArchive & operator<<(double x) { store_fundamental(x); return *this; }
-    MockArchive & operator<<(long x) { store_fundamental(x); return *this; }
-    MockArchive & operator<<(unsigned long x) { store_fundamental(x); return *this; }
-    MockArchive & operator<<(std::complex<double> x)
+    mock_archive & operator<<(double x) { store_fundamental(x); return *this; }
+    mock_archive & operator<<(long x) { store_fundamental(x); return *this; }
+    mock_archive & operator<<(unsigned long x) { store_fundamental(x); return *this; }
+    mock_archive & operator<<(std::complex<double> x)
     {
         *this << x.real() << x.imag();
         return *this;
@@ -25,7 +25,7 @@ public:
 
     // Store complex_op<T>
     template<typename T>
-    MockArchive & operator<<(const alps::alea::complex_op<T> &x)
+    mock_archive & operator<<(const alps::alea::complex_op<T> &x)
     {
         *this << x.rere() << x.reim() << x.imre() << x.imim();
         return *this;
@@ -33,7 +33,7 @@ public:
 
     // Store ALEA results
     template <typename T>
-    typename std::enable_if<alps::alea::is_alea_result<T>::value, MockArchive &>::type
+    typename std::enable_if<alps::alea::is_alea_result<T>::value, mock_archive &>::type
     operator<<(const T &result)
     {
         save(*this, result, 0);
@@ -41,10 +41,10 @@ public:
     }
 
     // Extract simple types
-    MockArchive & operator>>(double &x) { extract_fundamental(x); return *this; }
-    MockArchive & operator>>(long &x) { extract_fundamental(x); return *this; }
-    MockArchive & operator>>(unsigned long &x) { extract_fundamental(x); return *this; }
-    MockArchive & operator>>(std::complex<double> &x) {
+    mock_archive & operator>>(double &x) { extract_fundamental(x); return *this; }
+    mock_archive & operator>>(long &x) { extract_fundamental(x); return *this; }
+    mock_archive & operator>>(unsigned long &x) { extract_fundamental(x); return *this; }
+    mock_archive & operator>>(std::complex<double> &x) {
       double r, i;
       extract_fundamental(r);
       extract_fundamental(i);
@@ -54,7 +54,7 @@ public:
 
     // Extract complex_op<T>
     template<typename T>
-    MockArchive & operator>>(alps::alea::complex_op<T> &x)
+    mock_archive & operator>>(alps::alea::complex_op<T> &x)
     {
         *this >> x.rere() >> x.reim() >> x.imre() >> x.imim();
         return *this;
@@ -62,7 +62,7 @@ public:
 
     // Extract ALEA results
     template <typename T>
-    typename std::enable_if<alps::alea::is_alea_result<T>::value, MockArchive &>::type
+    typename std::enable_if<alps::alea::is_alea_result<T>::value, mock_archive &>::type
     operator>>(T &result)
     {
         load(*this, result, 0);
@@ -91,8 +91,8 @@ private:
     std::queue<unsigned char> buf;
 };
 
-TEST(twogauss_serialize_case, MockArchive) {
-    MockArchive archive;
+TEST(twogauss_serialize_case, mock_archive) {
+    mock_archive archive;
 
     archive << (double)3.14
             << (long)-123456
@@ -134,7 +134,7 @@ public:
             in_acc << std::vector<value_type>{twogauss_data[i][0], twogauss_data[i][1]};
         auto in = in_acc.result();
 
-        MockArchive archive;
+        mock_archive archive;
         archive << in; // serialize
 
         Acc out_acc(2);

--- a/alea/test/stream_serializer.cpp
+++ b/alea/test/stream_serializer.cpp
@@ -1,0 +1,141 @@
+#include <alps/alea/plugin/stream_serializer.hpp>
+
+#include "gtest/gtest.h"
+#include "dataset.hpp"
+
+#include <vector>
+#include <queue>
+#include <cstdint>
+
+// Mock class that emulates Boost/HPX serialization archive
+class MockArchive {
+
+public:
+
+    MockArchive() {}
+
+    // Store simple types
+    MockArchive & operator<<(double x) { store_fundamental(x); return *this; }
+    MockArchive & operator<<(long x) { store_fundamental(x); return *this; }
+    MockArchive & operator<<(unsigned long x) { store_fundamental(x); return *this; }
+    MockArchive & operator<<(std::complex<double> x)
+    {
+        *this << x.real() << x.imag();
+        return *this;
+    }
+
+    // Store complex_op<T>
+    template<typename T>
+    MockArchive & operator<<(const alps::alea::complex_op<T> &x)
+    {
+        *this << x.rere() << x.reim() << x.imre() << x.imim();
+        return *this;
+    }
+
+    // Store ALEA results
+    template <typename T>
+    typename std::enable_if<alps::alea::is_alea_result<T>::value, MockArchive &>::type
+    operator<<(const T &result)
+    {
+        save(*this, result, 0);
+        return *this;
+    }
+
+    // Extract simple types
+    MockArchive & operator>>(double &x) { extract_fundamental(x); return *this; }
+    MockArchive & operator>>(long &x) { extract_fundamental(x); return *this; }
+    MockArchive & operator>>(unsigned long &x) { extract_fundamental(x); return *this; }
+    MockArchive & operator>>(std::complex<double> &x) {
+      double r, i;
+      extract_fundamental(r);
+      extract_fundamental(i);
+      x = std::complex<double>(r, i);
+    }
+
+    // Extract complex_op<T>
+    template<typename T>
+    MockArchive & operator>>(alps::alea::complex_op<T> &x)
+    {
+        *this >> x.rere() >> x.reim() >> x.imre() >> x.imim();
+        return *this;
+    }
+
+    // Extract ALEA results
+    template <typename T>
+    typename std::enable_if<alps::alea::is_alea_result<T>::value, MockArchive &>::type
+    operator>>(T &result)
+    {
+        load(*this, result, 0);
+        return *this;
+    }
+
+private:
+
+    template<typename T>
+    void store_fundamental(T x) {
+        std::int8_t* p = reinterpret_cast<std::int8_t*>(&x);
+        for(int n = 0; n < sizeof(T); ++n)
+            buf.push(*(p + n));
+    }
+
+    template<typename T>
+    void extract_fundamental(T &x) {
+        std::int8_t* p = reinterpret_cast<std::int8_t*>(&x);
+        for(int n = 0; n < sizeof(T); ++n) {
+            *(p + n) = buf.front();
+            buf.pop();
+        }
+    }
+
+    // FIFO container with raw byte representation of stored values
+    std::queue<std::int8_t> buf;
+};
+
+template <typename Acc>
+class twogauss_serialize_case
+    : public ::testing::Test
+{
+public:
+    typedef typename alps::alea::traits<Acc>::value_type value_type;
+    typedef typename alps::alea::traits<Acc>::result_type result_type;
+
+    twogauss_serialize_case() { }
+
+    void test_result()
+    {
+        Acc in_acc(2);
+        for (size_t i = 0; i != twogauss_count; ++i)
+            in_acc << std::vector<value_type>{twogauss_data[i][0], twogauss_data[i][1]};
+        auto in = in_acc.result();
+
+        MockArchive archive;
+        archive << in; // serialize
+
+        Acc out_acc(2);
+        auto out = out_acc.result();
+
+        archive >> out; // deserialize
+
+        EXPECT_EQ(in, out);
+    }
+};
+
+using namespace alps::alea;
+
+typedef ::testing::Types<
+        mean_acc<double>
+      , mean_acc<std::complex<double> >
+      , var_acc<double>
+      , var_acc<std::complex<double> >
+      , var_acc<std::complex<double>, elliptic_var>
+      , cov_acc<double>
+      , cov_acc<std::complex<double> >
+      , cov_acc<std::complex<double>, elliptic_var>
+      , autocorr_acc<double>
+      , autocorr_acc<std::complex<double> >
+      , batch_acc<double>
+      , batch_acc<std::complex<double> >
+    > stream_serializable;
+
+TYPED_TEST_CASE(twogauss_serialize_case, stream_serializable);
+TYPED_TEST(twogauss_serialize_case, test_result) { this->test_result(); }


### PR DESCRIPTION
This plugin should allow for Boost/HPX serialization of `*_result<T>` types.
To enable the plugin for all supported ALEA result types in an HPX application one must include `alps/alea/plugin/stream_serializer.hpp` as follows,

```c++
#include <hpx/runtime/serialization/serialize.hpp>
#include <hpx/runtime/serialization/complex.hpp>

#include <alps/alea/plugin/stream_serializer.hpp>

namespace alps { namespace alea {
HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE((template <typename T>), (mean_result<T>));
HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE((template <typename T>), (var_result<T>));
HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE((template <typename T>), (cov_result<T>));
HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE((template <typename T>), (autocorr_result<T>));
HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE((template <typename T>), (batch_result<T>));
}}
```