### PR TITLE
return by const ref instead of value

### DIFF
--- a/gf/include/alps/gf/gf_base.hpp
+++ b/gf/include/alps/gf/gf_base.hpp
@@ -239,7 +239,7 @@ namespace alps {
          * @return value at the specific position
          */
         template<class...Indices>
-        typename std::enable_if < (sizeof...(Indices) == sizeof...(MESHES)), VTYPE >::type
+        typename std::enable_if < (sizeof...(Indices) == sizeof...(MESHES)), const VTYPE & >::type
         operator()(Indices...inds) const {
           // check that index types are the same as mesh indices
           static_assert(check_mesh<Indices...>::type::value, "Index type is inconsistent with mesh index type.");
@@ -586,7 +586,7 @@ namespace alps {
          * @return element for the provided indices
          */
         template<class ... Indices>
-        VTYPE value(Indices...inds) const {
+        const VTYPE & value(Indices...inds) const {
           return data_(inds()...);
         }
 

--- a/utilities/include/alps/numeric/tensors/data_storage.hpp
+++ b/utilities/include/alps/numeric/tensors/data_storage.hpp
@@ -51,7 +51,7 @@ namespace alps {
         /// @return const-reference to the data at point i
         inline const T& data(size_t i) const {return data_[i];};
         /// bracket operators
-        inline T  operator()(size_t i) const {return data_[i];};
+        inline const T& operator()(size_t i) const {return data_[i];};
         inline T& operator()(size_t i) {return data_[i];};
         /// @return data size
         size_t size() const {return data_.size();}

--- a/utilities/include/alps/numeric/tensors/data_view.hpp
+++ b/utilities/include/alps/numeric/tensors/data_view.hpp
@@ -66,7 +66,7 @@ namespace alps {
         /// @return const-reference to the data at point i
         const T& data(size_t i) const {return data_slice_.data(i + offset_);};
         /// bracket operators
-        inline T  operator()(size_t i) const {return data_slice_.data(i + offset_);};
+        inline const T&  operator()(size_t i) const {return data_slice_.data(i + offset_);};
         inline T& operator()(size_t i) {return data_slice_.data(i + offset_);};
         /// @return buffer size
         size_t size() const {return size_;}

--- a/utilities/include/alps/numeric/tensors/tensor_base.hpp
+++ b/utilities/include/alps/numeric/tensors/tensor_base.hpp
@@ -178,7 +178,7 @@ namespace alps {
          * @return value of tensor at the (t1, indices...) point
          */
         template<typename ...IndexTypes>
-        T operator()(typename std::enable_if < sizeof...(IndexTypes) == Dim - 1, size_t >::type t1, IndexTypes ... indices) const {
+        const T & operator()(typename std::enable_if < sizeof...(IndexTypes) == Dim - 1, size_t >::type t1, IndexTypes ... indices) const {
           return storage_.data(index(t1, indices...));
         }
 


### PR DESCRIPTION
`const` element access should probably return by `const ref` instead of by value. This is how it is done for both `std::vector` and `boost::multiarray`. I think it is more efficient as well as more flexible since it leaves it up to the consumer how they want to take the value.