### PR TITLE
Introduced selective builds of ALPSCore components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,22 +50,25 @@ if (Testing AND NOT DocumentationOnly)
     include(ALPSEnableTests) #defined in common/cmake
 endif(Testing AND NOT DocumentationOnly)
 
+# Normalize the list of disabled modules (aka packages)
+# FIXME: this inconsistent dual-naming "${module}" vs "alps-${module}" should go away!
+foreach(module_ ${ALPS_MODULES_DISABLE})
+  list(APPEND ALPS_MODULES_DISABLE "alps-${module_}")
+endforeach()
+
 # each module is defined as a cmake project in a subdirectory
-# also add in alpscore_config_main_() at common/cmake/ALPSCoreConfig.cmake.in
-add_subdirectory(utilities)
-alps_add_module(alps-utilities utilities)
-add_subdirectory(hdf5)
-alps_add_module(alps-hdf5 hdf5)
-add_subdirectory(accumulators)
-alps_add_module(alps-accumulators accumulators)
-add_subdirectory(params)
-alps_add_module(alps-params params)
-add_subdirectory(mc)
-alps_add_module(alps-mc mc)
-add_subdirectory(gf)
-alps_add_module(alps-gf gf)
-add_subdirectory(alea)
-alps_add_module(alps-alea alea)
+# also add to utilities/include/config.hpp.in under "Available ALPSCore components"
+set(ALPS_KNOWN_COMPONENTS)
+foreach(module_ utilities hdf5 accumulators params mc gf alea)
+  list(FIND ALPS_MODULES_DISABLE ${module_} disabled_index_)
+  if (disabled_index_ EQUAL -1)
+    add_subdirectory(${module_})
+    alps_add_module("alps-${module_}" ${module_})
+    list(APPEND ALPS_KNOWN_COMPONENTS ${module_})
+  else()
+    message("\nNOTE: module ${module_} is disabled")
+  endif()
+endforeach()
 
 #Doxygen building is a function to prevent namespace damage
 function(build_documentation_)

--- a/common/cmake/ALPSCommonModuleDefinitions.cmake
+++ b/common/cmake/ALPSCommonModuleDefinitions.cmake
@@ -142,6 +142,12 @@ endmacro(add_hdf5)
 # Usage: add_alps_package(pkgname1 pkgname2...)
 # Sets variable ${PROJECT_NAME}_DEPENDS
 macro(add_alps_package)
+    foreach(pkg_ ${ARGV})
+      list(FIND ALPS_MODULES_DISABLE ${pkg_} disabled_index_)
+      if (NOT disabled_index_ EQUAL -1)
+        message(FATAL_ERROR "Module ${PROJECT_NAME} depends on ${pkg_} which is disabled.")
+      endif()
+    endforeach()
     list(APPEND ${PROJECT_NAME}_DEPENDS ${ARGV})
     foreach(pkg_ ${ARGV})
         if (DEFINED ALPS_GLOBAL_BUILD)
@@ -169,6 +175,7 @@ endmacro(add_alps_package)
 # After `EXTRA`, `extra_srcs` are added verbatim
 # Defines ${PROJECT_NAME} target
 # Exports alps::${PROJECT_NAME} target
+# Defines internal cache variable ALPS_HAVE_ALPS_${MODULE} (where MODULE=upcase(PROJECT_NAME))
 function(add_this_package)
   include(CMakeParseArguments)
   cmake_parse_arguments(THIS_PACKAGE "" "" "EXTRA" ${ARGV})
@@ -208,6 +215,10 @@ function(add_this_package)
     endif()
   endif(ALPS_HAVE_MPI)
 
+  string(REPLACE "alps-" "" upcase_project_name_ ${PROJECT_NAME})
+  string(TOUPPER ${upcase_project_name_} upcase_project_name_)
+  set(ALPS_HAVE_ALPS_${upcase_project_name_} 1 CACHE INTERNAL "")
+  
   install(TARGETS ${PROJECT_NAME} 
           EXPORT ${PROJECT_NAME} 
           LIBRARY DESTINATION lib

--- a/common/cmake/ALPSCoreConfig.cmake.in
+++ b/common/cmake/ALPSCoreConfig.cmake.in
@@ -36,7 +36,7 @@ function(alpscore_config_main_)
     endif()
 
     # Create a list of known components
-    set(known_components_ utilities hdf5 accumulators params mc gf alea)
+    set(known_components_ @ALPS_KNOWN_COMPONENTS@)
 
     # if no components required - search for everything
     if (NOT ALPSCore_FIND_COMPONENTS)
@@ -82,6 +82,7 @@ function(alpscore_config_main_)
     endif()
     
     set(ALPSCore_LIBRARIES ${ALPSCore_LIBRARIES} PARENT_SCOPE)
+    set(ALPSCore_COMPONENTS ${ALPSCore_FIND_COMPONENTS} PARENT_SCOPE)
 endfunction(alpscore_config_main_)
 
 

--- a/utilities/include/config.hpp.in
+++ b/utilities/include/config.hpp.in
@@ -9,6 +9,15 @@
 // ALPSCore version (defined since 1.0.0.1)
 #cmakedefine ALPSCORE_VERSION ${ALPSCORE_VERSION}
 
+// Available ALPSCore components
+#cmakedefine ALPS_HAVE_ALPS_UTILITIES
+#cmakedefine ALPS_HAVE_ALPS_HDF5
+#cmakedefine ALPS_HAVE_ALPS_ACCUMULATORS
+#cmakedefine ALPS_HAVE_ALPS_PARAMS
+#cmakedefine ALPS_HAVE_ALPS_MC
+#cmakedefine ALPS_HAVE_ALPS_GF
+#cmakedefine ALPS_HAVE_ALPS_ALEA
+
 //
 // C headers
 //


### PR DESCRIPTION
This is to partially address #212 (in particular, https://github.com/ALPSCore/ALPSCore/issues/212#issuecomment-364699130)

1. To exclude a component (and its testsuite) from being built, add
   it's name to CMake list `ALPS_MODULES_DISABLE` ::
```sh
        cmake .. -DALPS_MODULES_DISABLE=accumulators\;mc
```
2. If some component depends on a disabled component, the dependent component refuses to build.
   One needs to disable all dependent components explicitly.

3. The client code may inspect CMake list `ALPSCore_COMPONENTS` after
   `find_package(ALPSCore)` to determine if a component is available.

4. The cleint C++ code also has preprocessor symbols `ALPS_HAVE_ALPS_*` defined,
   e.g. `ALPS_HAVE_ALPS_GF` or `ALPS_HAVE_ALPS_ACCUMULATORS`, if the corresponding
   component is built.