### PR TITLE
RFC: [alea] add support for accumulating std::array

### DIFF
--- a/alea/include/alps/alea/autocorr.hpp
+++ b/alea/include/alps/alea/autocorr.hpp
@@ -67,8 +67,8 @@ class autocorr_acc
 {
 public:
     using value_type = T;
-    typedef typename bind<circular_var, T>::var_type var_type;
-    typedef var_acc<T, circular_var> level_acc_type;
+    using var_type = typename bind<circular_var, T>::var_type;
+    using level_acc_type = var_acc<T, circular_var>;
 
 public:
     autocorr_acc(size_t size=1, size_t batch_size=1, size_t granularity=2);

--- a/alea/include/alps/alea/autocorr.hpp
+++ b/alea/include/alps/alea/autocorr.hpp
@@ -66,7 +66,7 @@ template <typename T>
 class autocorr_acc
 {
 public:
-    typedef T value_type;
+    using value_type = T;
     typedef typename bind<circular_var, T>::var_type var_type;
     typedef var_acc<T, circular_var> level_acc_type;
 
@@ -83,18 +83,7 @@ public:
     size_t size() const { return size_; }
 
     /** Add computed vector to the accumulator */
-    autocorr_acc &operator<<(const computed<T> &src) { add(src, 1); return *this; }
-
-    /** Add Eigen vector-valued expression to accumulator */
-    template <typename Derived>
-    autocorr_acc &operator<<(const Eigen::DenseBase<Derived> &o)
-    { return *this << eigen_adapter<T,Derived>(o); }
-
-    /** Add `std::vector` to accumulator */
-    autocorr_acc &operator<<(const std::vector<T> &o) { return *this << vector_adapter<T>(o); }
-
-    /** Add scalar value to accumulator */
-    autocorr_acc &operator<<(T o) { return *this << value_adapter<T>(o); }
+    autocorr_acc& operator<<(const computed<T>& src){ add(src, 1); return *this; }
 
     /** Merge partial result into accumulator */
     autocorr_acc &operator<<(const autocorr_result<T> &result);
@@ -218,6 +207,7 @@ bool operator!=(const autocorr_result<T> &r1, const autocorr_result<T> &r2)
     return !operator==(r1, r2);
 }
 
+template<typename T> struct is_alea_acc<autocorr_acc<T>> : std::true_type {};
 template<typename T> struct is_alea_result<autocorr_result<T>> : std::true_type {};
 
 template <typename T>

--- a/alea/include/alps/alea/batch.hpp
+++ b/alea/include/alps/alea/batch.hpp
@@ -82,7 +82,7 @@ template <typename T>
 class batch_acc
 {
 public:
-    typedef T value_type;
+    using value_type = T;
 
 public:
     batch_acc(size_t size=1, size_t num_batches=256, size_t base_size=1);
@@ -104,18 +104,7 @@ public:
     size_t num_batches() const { return num_batches_; }
 
     /** Add computed vector to the accumulator */
-    batch_acc &operator<<(const computed<T> &src) { add(src, 1); return *this; }
-
-    /** Add Eigen vector-valued expression to accumulator */
-    template <typename Derived>
-    batch_acc &operator<<(const Eigen::DenseBase<Derived> &o)
-    { return *this << eigen_adapter<T,Derived>(o); }
-
-    /** Add `std::vector` to accumulator */
-    batch_acc &operator<<(const std::vector<T> &o) { return *this << vector_adapter<T>(o); }
-
-    /** Add scalar value to accumulator */
-    batch_acc &operator<<(T o) { return *this << value_adapter<T>(o); }
+    batch_acc& operator<<(const computed<T>& src){ add(src, 1); return *this; }
 
     /** Merge partial result into accumulator */
     batch_acc &operator<<(const batch_result<T> &result);
@@ -249,6 +238,7 @@ bool operator!=(const batch_result<T> &r1, const batch_result<T> &r2)
     return !operator==(r1, r2);
 }
 
+template<typename T> struct is_alea_acc<batch_acc<T>> : std::true_type {};
 template<typename T> struct is_alea_result<batch_result<T>> : std::true_type {};
 
 template <typename T>

--- a/alea/include/alps/alea/computed.hpp
+++ b/alea/include/alps/alea/computed.hpp
@@ -11,6 +11,7 @@
 #include <complex>
 
 #include <vector>
+#include <array>
 #include <Eigen/Dense>
 
 #include <alps/alea/core.hpp>
@@ -21,6 +22,7 @@
 namespace alps { namespace alea {
     template <typename T> class value_adapter;
     template <typename T> class vector_adapter;
+    template <typename T, size_t N> class array_adapter;
     template <typename T, typename Derived> class eigen_adapter;
 }}
 
@@ -39,6 +41,11 @@ template <typename T>
 vector_adapter<T> make_adapter(const std::vector<T> &v)
 {
     return vector_adapter<T>(v);
+}
+
+template<typename T, size_t N>
+array_adapter<T,N> make_array_adapter(const std::array<T, N> &a){
+  return array_adapter<T,N>(a);
 }
 
 template <typename T>
@@ -109,6 +116,28 @@ private:
     const std::vector<T> &in_;
 };
 
+template <typename T, size_t N> class array_adapter : public computed<T> {
+public:
+  typedef T value_type;
+
+public:
+  array_adapter(const std::array<T, N> &in) : in_(in) {}
+
+  size_t size() const { return in_.size(); }
+
+  void add_to(view<T> out) const {
+    if (out.size() != in_.size())
+      throw size_mismatch();
+    for (size_t i = 0; i != in_.size(); ++i)
+      out.data()[i] += in_[i];
+  }
+
+  ~array_adapter() {}
+
+private:
+  const std::array<T, N> &in_;
+};
+
 template <typename T, typename Derived>
 class eigen_adapter
     : public computed<T>
@@ -177,5 +206,33 @@ private:
     adder_type adder_;
     size_t size_;
 };
+
+/** Add scalar value to accumulator */
+template<typename AccType>
+typename std::enable_if<is_alea_acc<AccType>::value, AccType&>::type
+operator<<(AccType& acc, const typename AccType::value_type& v){
+  return acc << value_adapter<typename AccType::value_type>(v);
+}
+
+/** Add Eigen vector-valued expression to accumulator */
+template<typename AccType, typename Derived>
+typename std::enable_if<is_alea_acc<AccType>::value, AccType&>::type
+operator<<(AccType& acc, const Eigen::DenseBase<Derived>& v){
+  return acc << eigen_adapter<typename AccType::value_type, Derived>(v);
+}
+
+/** Add `std::vector` to accumulator */
+template<typename AccType>
+typename std::enable_if<is_alea_acc<AccType>::value, AccType&>::type
+operator<<(AccType& acc, const std::vector<typename AccType::value_type>& v){
+  return acc << vector_adapter<typename AccType::value_type>(v);
+}
+
+/** Add `std::array` to accumulator */
+template<typename AccType, size_t N>
+typename std::enable_if<is_alea_acc<AccType>::value, AccType&>::type
+operator<<(AccType& acc, const std::array<typename AccType::value_type, N>& v){
+  return acc << array_adapter<typename AccType::value_type, N>(v);
+}
 
 }}

--- a/alea/include/alps/alea/core.hpp
+++ b/alea/include/alps/alea/core.hpp
@@ -36,6 +36,9 @@ struct weight_mismatch : public std::exception { };
 template <typename T>
 struct traits;
 
+// Metafunction to detect ALEA accumulator types
+template<typename T> struct is_alea_acc : std::false_type {};
+
 // Metafunction to detect ALEA result types
 template<typename T> struct is_alea_result : std::false_type {};
 

--- a/alea/include/alps/alea/covariance.hpp
+++ b/alea/include/alps/alea/covariance.hpp
@@ -119,9 +119,9 @@ class cov_acc
 {
 public:
     using value_type = T;
-    typedef typename bind<Strategy, T>::var_type var_type;
-    typedef typename bind<Strategy, T>::cov_type cov_type;
-    typedef typename eigen<cov_type>::matrix cov_matrix_type;
+    using var_type = typename bind<Strategy, T>::var_type;
+    using cov_type =  typename bind<Strategy, T>::cov_type;
+    using cov_matrix_type = typename eigen<cov_type>::matrix;
 
 public:
     cov_acc(size_t size=1, size_t bundle_size=1);

--- a/alea/include/alps/alea/covariance.hpp
+++ b/alea/include/alps/alea/covariance.hpp
@@ -118,7 +118,7 @@ template <typename T, typename Strategy=circular_var>
 class cov_acc
 {
 public:
-    typedef T value_type;
+    using value_type = T;
     typedef typename bind<Strategy, T>::var_type var_type;
     typedef typename bind<Strategy, T>::cov_type cov_type;
     typedef typename eigen<cov_type>::matrix cov_matrix_type;
@@ -143,18 +143,7 @@ public:
     size_t batch_size() const { return current_.target(); }
 
     /** Add computed vector to the accumulator */
-    cov_acc &operator<<(const computed<T> &src) { add(src, 1); return *this; }
-
-    /** Add Eigen vector-valued expression to accumulator */
-    template <typename Derived>
-    cov_acc &operator<<(const Eigen::DenseBase<Derived> &o)
-    { return *this << eigen_adapter<T,Derived>(o); }
-
-    /** Add `std::vector` to accumulator */
-    cov_acc &operator<<(const std::vector<T> &o) { return *this << vector_adapter<T>(o); }
-
-    /** Add scalar value to accumulator */
-    cov_acc &operator<<(T o) { return *this << value_adapter<T>(o); }
+    cov_acc& operator<<(const computed<T>& src){ add(src, 1); return *this; }
 
     /** Merge partial result into accumulator */
     cov_acc &operator<<(const cov_result<T,Strategy> &result);
@@ -294,6 +283,10 @@ bool operator!=(const cov_result<T, Strategy> &r1, const cov_result<T, Strategy>
     return !operator==(r1, r2);
 }
 
+template<typename T> struct is_alea_acc<cov_acc<T, circular_var>> :
+    std::true_type {};
+template<typename T> struct is_alea_acc<cov_acc<T, elliptic_var>> :
+    std::true_type {};
 template<typename T> struct is_alea_result<cov_result<T, circular_var>> :
     std::true_type {};
 template<typename T> struct is_alea_result<cov_result<T, elliptic_var>> :

--- a/alea/include/alps/alea/mean.hpp
+++ b/alea/include/alps/alea/mean.hpp
@@ -97,6 +97,9 @@ template <typename T>
 class mean_acc
 {
 public:
+    using value_type = T;
+
+public:
     mean_acc(size_t size=1) : store_(new mean_data<T>(size)), size_(size) { }
 
     mean_acc(const mean_acc &other);
@@ -114,17 +117,6 @@ public:
 
     /** Add computed vector to the accumulator */
     mean_acc &operator<<(const computed<T> &src) { add(src, 1); return *this; }
-
-    /** Add Eigen vector-valued expression to accumulator */
-    template <typename Derived>
-    mean_acc &operator<<(const Eigen::DenseBase<Derived> &o)
-    { return *this << eigen_adapter<T,Derived>(o); }
-
-    /** Add `std::vector` to accumulator */
-    mean_acc &operator<<(const std::vector<T> &o) { return *this << vector_adapter<T>(o); }
-
-    /** Add scalar value to accumulator */
-    mean_acc &operator<<(T o) { return *this << value_adapter<T>(o); }
 
     /** Merge partial result into accumulator */
     mean_acc &operator<<(const mean_result<T> &result);
@@ -160,7 +152,6 @@ struct traits< mean_acc<T> >
 
 extern template class mean_acc<double>;
 extern template class mean_acc<std::complex<double> >;
-
 
 /**
  * Result of a mean accumulation
@@ -227,6 +218,7 @@ bool operator!=(const mean_result<T> &r1, const mean_result<T> &r2)
     return !operator==(r1, r2);
 }
 
+template<typename T> struct is_alea_acc<mean_acc<T>> : std::true_type {};
 template<typename T> struct is_alea_result<mean_result<T>> : std::true_type {};
 
 template <typename T>

--- a/alea/include/alps/alea/variance.hpp
+++ b/alea/include/alps/alea/variance.hpp
@@ -160,7 +160,7 @@ public:
     /** Return backend object used for storing estimands */
     const var_data<T,Strategy> &store() const { return *store_; }
 
-  protected:
+protected:
     void add(const computed<T> &source, size_t count, var_acc *cascade);
 
     void add_bundle(var_acc *cascade);

--- a/alea/include/alps/alea/variance.hpp
+++ b/alea/include/alps/alea/variance.hpp
@@ -118,7 +118,7 @@ template <typename T, typename Strategy=circular_var>
 class var_acc
 {
 public:
-    typedef typename bind<Strategy, T>::value_type value_type;
+    using value_type = T;
     typedef typename bind<Strategy, T>::var_type var_type;
 
 public:
@@ -143,17 +143,6 @@ public:
     /** Add computed vector to the accumulator */
     var_acc &operator<<(const computed<T> &src) { add(src, 1, nullptr); return *this; }
 
-    /** Add Eigen vector-valued expression to accumulator */
-    template <typename Derived>
-    var_acc &operator<<(const Eigen::DenseBase<Derived> &o)
-    { return *this << eigen_adapter<T,Derived>(o); }
-
-    /** Add `std::vector` to accumulator */
-    var_acc &operator<<(const std::vector<T> &o) { return *this << vector_adapter<T>(o); }
-
-    /** Add scalar value to accumulator */
-    var_acc &operator<<(T o) { return *this << value_adapter<T>(o); }
-
     /** Merge partial result into accumulator */
     var_acc &operator<<(const var_result<T,Strategy> &result);
 
@@ -171,7 +160,7 @@ public:
     /** Return backend object used for storing estimands */
     const var_data<T,Strategy> &store() const { return *store_; }
 
-protected:
+  protected:
     void add(const computed<T> &source, size_t count, var_acc *cascade);
 
     void add_bundle(var_acc *cascade);
@@ -288,6 +277,10 @@ bool operator!=(const var_result<T, Strategy> &r1, const var_result<T, Strategy>
     return !operator==(r1, r2);
 }
 
+template<typename T> struct is_alea_acc<var_acc<T, circular_var>> :
+    std::true_type {};
+template<typename T> struct is_alea_acc<var_acc<T, elliptic_var>> :
+    std::true_type {};
 template<typename T> struct is_alea_result<var_result<T, circular_var>> :
     std::true_type {};
 template<typename T> struct is_alea_result<var_result<T, elliptic_var>> :

--- a/alea/include/alps/alea/variance.hpp
+++ b/alea/include/alps/alea/variance.hpp
@@ -119,7 +119,7 @@ class var_acc
 {
 public:
     using value_type = T;
-    typedef typename bind<Strategy, T>::var_type var_type;
+    using var_type = typename bind<Strategy, T>::var_type;
 
 public:
     var_acc(size_t size=1, size_t bundle_size=1);


### PR DESCRIPTION
This adds support for accumulating `std::array`.

It also introduces `is_alea_acc` metafunction and makes insertion operators for non `computed` types into free functions defined in `computed.hpp` where the adapters are defined. I think this makes sense because it removes the 5x duplication of these functions in the definition of every accumulator, shortens the actual accumulator interfaces and doesn't special case any types. The user can add support for accumulating custom types by just following how it is done for `std` types in `computed.hpp`. The only downside I can think of is that now these functions are not explicitly instantiated with the accumulators. However since they are basically one-liners this is probably not too big of a deal.

This is done on top of #446. I will retarget to master when that is merged. 