### PR TITLE
Add Travis CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+language: cpp
+sudo: required
+dist: trusty
+
+compiler:
+  - gcc
+  - clang
+
+addons:
+  apt:
+    sources:
+      # Boost 1.58
+      - sourceline: ppa:kzemek/boost
+    packages:
+      - libboost1.58-dev
+      - openmpi-bin
+      - openmpi-common
+      - openmpi-doc
+      - libopenmpi-dev
+      - libhdf5-serial-dev
+
+install: true
+
+before_script:
+  - export OMPI_CC=${CC}
+  - export OMPI_CXX=${CXX}
+
+script:
+  # Stop on first error
+  - set -e
+
+  # Build ALPSCore
+  - mkdir build
+  - mkdir install
+  - cd build
+  - |
+    cmake ..                                              \
+    -DCMAKE_BUILD_TYPE=Debug                              \
+    -DCMAKE_C_COMPILER=mpicc                              \
+    -DCMAKE_CXX_COMPILER=mpic++                           \
+    -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/installed    \
+    -DALPS_INSTALL_EIGEN=true
+  - make -j3
+  - make test
+  - make install


### PR DESCRIPTION
Travis CI is a free continuous integration service that is easily connectable to GitHub repositories.
Repository admins can configure automatically triggered and scheduled builds of `master`, other/all branches and new pull requests.