### PR TITLE
avoid overwrite of file in different tests by giving a unique name to…

### DIFF
--- a/gf/test/two_index_gf_test.cpp
+++ b/gf/test/two_index_gf_test.cpp
@@ -232,12 +232,12 @@ TEST_F(TwoIndexGFTest, TailSaveLoad)
     EXPECT_EQ(0,gft.max_tail_order());
     EXPECT_EQ(0,(denmat-gft.tail(0)).norm());
     {
-        alps::hdf5::archive oar("gf_2i_tailsaveload.h5","w");
+        alps::hdf5::archive oar("gf_2i_tailsaveloadX.h5","w");
         gft(g::matsubara_index(4),g::index(1))=std::complex<double>(7., 3.);
         oar["/gft"] << gft;
     }
     {
-        alps::hdf5::archive iar("gf_2i_tailsaveload.h5");
+        alps::hdf5::archive iar("gf_2i_tailsaveloadX.h5");
 
         iar["/gft"] >> gft2;
     }


### PR DESCRIPTION
… test file

This uses a different file name in two_index_gf_test and gf_new_tail_test so that the tests can be run in parallel. Fixes test failure with parallel testing.