### PR TITLE
C++14 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,16 @@ addons:
 install: true
 
 env:
-  - ENABLE_MPI=ON ALPS_CC=mpicc ALPS_CXX=mpic++
-  - ENABLE_MPI=OFF
+  - ENABLE_MPI=ON ALPS_CC=mpicc ALPS_CXX=mpic++ ALPS_CXX_STD=c++11
+  - ENABLE_MPI=OFF ALPS_CXX_STD=c++11
+  - ENABLE_MPI=ON ALPS_CC=mpicc ALPS_CXX=mpic++ ALPS_CXX_STD=c++14
+  - ENABLE_MPI=OFF ALPS_CXX_STD=c++14
 
 before_script:
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  - sudo apt-get update
+  - sudo apt-get install -y --allow-unauthenticated g++-5
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5
   - export OMPI_CC=${CC}
   - export OMPI_CXX=${CXX}
 
@@ -41,6 +47,7 @@ script:
     cmake ..                                              \
     -DCMAKE_BUILD_TYPE=Debug                              \
     -DCMAKE_C_COMPILER=${ALPS_CC:-${CC}}                  \
+    -DALPS_CXX_STD=$ALPS_CXX_STD                          \
     -DCMAKE_CXX_COMPILER=${ALPS_CXX:-${CXX}}              \
     -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/installed    \
     -DALPS_INSTALL_EIGEN=true                             \

--- a/params/src/dict_value.cpp
+++ b/params/src/dict_value.cpp
@@ -7,6 +7,8 @@
 /** @file dict_value.cpp
     Contains implementation of some alps::params_ns::dict_value members */
 
+#include <boost/version.hpp>
+
 #include <alps/params/dict_value.hpp>
 #include <alps/params/hdf5_variant.hpp>
 
@@ -155,7 +157,13 @@ namespace alps {
                 return strm;
             }
 
-            struct print_visitor : public boost::static_visitor<std::ostream&> {
+            struct print_visitor {
+#if __cplusplus == 201402L && BOOST_VERSION == 105800
+                // Workaround for a bug in boost 1.58 (C++14).
+                // Defining result_type ledas to a compiler error.
+#else
+                typedef std::ostream& result_type;
+#endif
                 std::ostream& os_;
 
                 print_visitor(std::ostream& os) : os_(os) {}


### PR DESCRIPTION
We build ALPSCore with C++14 in Travis CI.
As expected, builds with C++14 fail due to the bug in Boost 1.58.