### PR TITLE
Build failure in Travis CI due to connection time out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ addons:
       - openmpi-doc
       - libopenmpi-dev
       - libhdf5-serial-dev
+    config:
+      retries: true
 
 install: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ script:
     -DCMAKE_CXX_COMPILER=${ALPS_CXX:-${CXX}}              \
     -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/installed    \
     -DALPS_INSTALL_EIGEN=true                             \
+    -DBUNDLE_DOWNLOAD_TRIES=3                             \
     -DENABLE_MPI=$ENABLE_MPI
   - make -j3
   - make test

--- a/common/cmake/ALPSEnableEigen.cmake
+++ b/common/cmake/ALPSEnableEigen.cmake
@@ -74,11 +74,17 @@ function(add_eigen)
       message(STATUS "Trying to download and unpack Eigen3")
       if (NOT EXISTS "${ALPS_EIGEN_TGZ_FILE}")
         message(STATUS "Downloading Eigen3, timeout 600 sec")
-        file(DOWNLOAD ${ALPS_EIGEN_DOWNLOAD_LOCATION} ${ALPS_EIGEN_TGZ_FILE}
-          INACTIVITY_TIMEOUT 60
-          TIMEOUT 600
-          STATUS status_
-          SHOW_PROGRESS)
+        # Attempt to download four times
+        foreach(loop_var RANGE 3)
+          file(DOWNLOAD ${ALPS_EIGEN_DOWNLOAD_LOCATION} ${ALPS_EIGEN_TGZ_FILE}
+            INACTIVITY_TIMEOUT 60
+            TIMEOUT 600
+            STATUS status_
+            SHOW_PROGRESS)
+          if (status_ EQUAL 0)
+            break()
+          endif()
+        endforeach()
         if (status_ EQUAL 0)
           message(STATUS "Downloaded successfully")
         else()

--- a/common/cmake/ALPSEnableEigen.cmake
+++ b/common/cmake/ALPSEnableEigen.cmake
@@ -8,6 +8,10 @@ set(ALPS_EIGEN_DOWNLOAD_LOCATION "http://bitbucket.org/eigen/eigen/get/${ALPS_EI
     CACHE STRING "Eigen3 download location")
 mark_as_advanced(ALPS_EIGEN_DOWNLOAD_LOCATION)
 
+if (NOT DEFINED BUNDLE_DOWNLOAD_TRIES)
+  set(BUNDLE_DOWNLOAD_TRIES 1)
+endif()
+
 # Add eigen to the current module (target ${PROJECT_NAME})
 # Sets EIGEN3_VERSION variable in the parent scope
 function(add_eigen)
@@ -75,7 +79,7 @@ function(add_eigen)
       if (NOT EXISTS "${ALPS_EIGEN_TGZ_FILE}")
         message(STATUS "Downloading Eigen3, timeout 600 sec")
         # Attempt to download four times
-        foreach(loop_var RANGE 3)
+        foreach(loop_var RANGE ${BUNDLE_DOWNLOAD_TRIES})
           file(DOWNLOAD ${ALPS_EIGEN_DOWNLOAD_LOCATION} ${ALPS_EIGEN_TGZ_FILE}
             INACTIVITY_TIMEOUT 60
             TIMEOUT 600


### PR DESCRIPTION
Multiple builds in Travis CI sometimes fail due to connection time out (apt & Eigen3).
Here is some workaround for this issue.