### PR TITLE
[alea] Make `count()` consistent over accumulators.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,8 @@ target/
 # generated files
 *.pyc
 
-# stuff
+# IDE config files
 *.kdev*
+*.user
 *.project
 

--- a/alea/include/alps/alea/batch.hpp
+++ b/alea/include/alps/alea/batch.hpp
@@ -246,6 +246,10 @@ template <typename T>
 struct traits< batch_result<T> >
 {
     typedef T value_type;
+
+    // TODO: batch result supports multiple strategies
+    typedef typename make_real<T>::type var_type;
+    typedef T cov_type;
     typedef circular_var strategy_type;
 
     const static bool HAVE_MEAN  = true;

--- a/alea/include/alps/alea/covariance.hpp
+++ b/alea/include/alps/alea/covariance.hpp
@@ -63,10 +63,10 @@ public:
     size_t size() const { return data_.rows(); }
 
     /** Returns sample size, i.e., number of accumulated data points */
-    double count() const { return count_; }
+    size_t count() const { return count_; }
 
     /** Returns sample size, i.e., number of accumulated data points */
-    double &count() { return count_; }
+    size_t &count() { return count_; }
 
     /** Returns sum of squared weights */
     double count2() const { return count2_; }
@@ -89,7 +89,8 @@ public:
 private:
     column<T> data_;
     cov_matrix_type data2_;
-    double count_, count2_;
+    size_t count_;
+    double count2_;
 
     friend class cov_acc<T, Strategy>;
     friend class cov_result<T, Strategy>;

--- a/alea/include/alps/alea/result.hpp
+++ b/alea/include/alps/alea/result.hpp
@@ -51,6 +51,9 @@ public:
     bool valid() const;
 
     /** Number of components of the random vector (e.g., size of mean) */
+    size_t size() const;
+
+    /** Returns number of accumulated data points */
     size_t count() const;
 
     /** Returns sample mean */

--- a/alea/include/alps/alea/variance.hpp
+++ b/alea/include/alps/alea/variance.hpp
@@ -65,10 +65,10 @@ public:
     size_t size() const { return data_.rows(); }
 
     /** Returns sample size, i.e., number of accumulated data points */
-    double count() const { return count_; }
+    size_t count() const { return count_; }
 
     /** Returns sample size, i.e., number of accumulated data points */
-    double &count() { return count_; }
+    size_t &count() { return count_; }
 
     /** Returns sum of squared weights */
     double count2() const { return count2_; }
@@ -91,7 +91,8 @@ public:
 private:
     column<T> data_;
     column<var_type> data2_;
-    double count_, count2_;
+    size_t count_;
+    double count2_;
 
     friend class var_acc<T, Strategy>;
     friend class var_result<T, Strategy>;

--- a/alea/src/covariance.cpp
+++ b/alea/src/covariance.cpp
@@ -228,7 +228,7 @@ void cov_result<T,Str>::reduce(const reducer &r, bool pre_commit, bool post_comm
         store_->convert_to_sum();
         r.reduce(view<T>(store_->data().data(), store_->data().rows()));
         r.reduce(view<cov_type>(store_->data2().data(), store_->data2().size()));
-        r.reduce(view<double>(&store_->count(), 1));
+        r.reduce(view<size_t>(&store_->count(), 1));
         r.reduce(view<double>(&store_->count2(), 1));
     }
     if (pre_commit && post_commit) {

--- a/alea/src/result.cpp
+++ b/alea/src/result.cpp
@@ -14,6 +14,14 @@ struct valid_visitor
     bool operator() (const Res &r) const { return r.valid(); }
 };
 
+struct size_visitor
+{
+    typedef size_t result_type;
+
+    template <typename Res>
+    size_t operator() (const Res &r) const { return r.size(); }
+};
+
 struct count_visitor
 {
     typedef size_t result_type;
@@ -111,6 +119,11 @@ private:
 bool result::valid() const
 {
     return boost::apply_visitor(valid_visitor(), res_);
+}
+
+size_t result::size() const
+{
+    return boost::apply_visitor(size_visitor(), res_);
 }
 
 size_t result::count() const

--- a/alea/src/variance.cpp
+++ b/alea/src/variance.cpp
@@ -233,7 +233,7 @@ void var_result<T,Str>::reduce(const reducer &r, bool pre_commit, bool post_comm
         store_->convert_to_sum();
         r.reduce(view<T>(store_->data().data(), store_->data().rows()));
         r.reduce(view<var_type>(store_->data2().data(), store_->data2().rows()));
-        r.reduce(view<double>(&store_->count(), 1));
+        r.reduce(view<size_t>(&store_->count(), 1));
         r.reduce(view<double>(&store_->count2(), 1));
     }
     if (pre_commit && post_commit) {

--- a/alea/test/CMakeLists.txt
+++ b/alea/test/CMakeLists.txt
@@ -4,6 +4,7 @@ set (test_src
      empty
      twogauss
      galois
+     result
      transform
      stream_serializer
     )

--- a/alea/test/result.cpp
+++ b/alea/test/result.cpp
@@ -1,0 +1,94 @@
+#include <alps/alea.hpp>
+#include <alps/testing/near.hpp>
+
+#include "gtest/gtest.h"
+
+template <typename Acc>
+class result_case
+    : public ::testing::Test
+{
+public:
+    typedef Acc acc_type;
+    typedef alps::alea::traits<Acc> acc_traits;
+    typedef typename acc_traits::store_type  store_type;
+    typedef typename acc_traits::value_type value_type;
+
+    typedef typename acc_traits::result_type result_type;
+    typedef alps::alea::traits<result_type> result_traits;
+
+    result_case()
+    {
+        acc_type acc(2);
+        for (size_t i = 0; i != 100; ++i)
+            acc << std::array<value_type, 2>{{1.0 * i, 2.0 * i}};
+
+        res = acc.result();
+        generic_res = acc.result();
+    }
+
+    void test_result_caps()
+    {
+        EXPECT_EQ(res.size(), generic_res.size());
+        EXPECT_EQ(res.count(), generic_res.count());
+        ALPS_EXPECT_NEAR(res.mean(), generic_res.mean<value_type>(), 1e-16);
+    }
+
+    // Thank you, C++, for this very nice way of doing "if/else".  Go die.
+
+    template <typename Res_>
+    typename std::enable_if<alps::alea::traits<Res_>::HAVE_VAR>::type test_var()
+    {
+        typedef typename alps::alea::traits<Res_>::value_type value_type;
+        ALPS_EXPECT_NEAR(res.var(), generic_res.var<value_type>(), 1e-16);
+    }
+
+    template <typename Res_>
+    typename std::enable_if<!alps::alea::traits<Res_>::HAVE_VAR>::type test_var()
+    {
+        typedef typename alps::alea::traits<Res_>::value_type value_type;
+        EXPECT_THROW(generic_res.var<value_type>(), alps::alea::estimate_unavailable);
+    }
+
+    template <typename Res_>
+    typename std::enable_if<alps::alea::traits<Res_>::HAVE_COV>::type test_cov()
+    {
+        typedef typename alps::alea::traits<Res_>::value_type value_type;
+        ALPS_EXPECT_NEAR(res.cov(), generic_res.cov<value_type>(), 1e-16);
+    }
+
+    template <typename Res_>
+    typename std::enable_if<!alps::alea::traits<Res_>::HAVE_COV>::type test_cov()
+    {
+        typedef typename alps::alea::traits<Res_>::value_type value_type;
+        EXPECT_THROW(generic_res.cov<value_type>(), alps::alea::estimate_unavailable);
+    }
+
+
+private:
+    result_type res;
+    alps::alea::result generic_res;
+};
+
+typedef ::testing::Types<
+      alps::alea::mean_acc<double>
+    , alps::alea::mean_acc<std::complex<double> >
+    , alps::alea::var_acc<double>
+    , alps::alea::var_acc<std::complex<double> >
+    , alps::alea::cov_acc<double>
+    , alps::alea::cov_acc<std::complex<double> >
+    , alps::alea::batch_acc<double>
+    , alps::alea::batch_acc<std::complex<double> >
+    > acc_types;
+
+
+TYPED_TEST_CASE(result_case, acc_types);
+
+TYPED_TEST(result_case, test_result_caps) { this->test_result_caps(); }
+
+TYPED_TEST(result_case, test_var) {
+    this->template test_var<typename TestFixture::result_type>();
+}
+
+TYPED_TEST(result_case, test_cov) {
+    this->template test_cov<typename TestFixture::result_type>();
+}


### PR DESCRIPTION
Also, adds some tests to the generic (variant-based) result class to match that.

Closes: #484
