### PR TITLE
Reset accumulators on slaves after MPI merge

### DIFF
--- a/accumulators/include/alps/accumulators/accumulator.hpp
+++ b/accumulators/include/alps/accumulators/accumulator.hpp
@@ -546,7 +546,6 @@ namespace alps {
 
 #ifdef ALPS_HAVE_MPI
             void collective_merge(alps::mpi::communicator const & comm, int root);
-            void collective_merge(alps::mpi::communicator const & comm, int root) const;
 #endif
 
             private:

--- a/accumulators/src/accumulator_wrapper.cpp
+++ b/accumulators/src/accumulator_wrapper.cpp
@@ -209,9 +209,7 @@ namespace alps {
 
         void accumulator_wrapper::collective_merge(alps::mpi::communicator const & comm, int root) {
             boost::apply_visitor(collective_merge_visitor(comm, root), m_variant);
-        }
-        void accumulator_wrapper::collective_merge(alps::mpi::communicator const & comm, int root) const {
-            boost::apply_visitor(collective_merge_visitor(comm, root), m_variant);
+            if (comm.rank()!=root) this->reset();
         }
 #endif
 

--- a/accumulators/test/repeated_merge.cpp
+++ b/accumulators/test/repeated_merge.cpp
@@ -5,7 +5,7 @@
  */
 
 /** @file repeated_merge.cpp
-    
+
     Test behavior of repeated accumulators merges.
 */
 
@@ -70,9 +70,10 @@ class AccumulatorTest : public ::testing::Test {
         {
             aa::accumulator_wrapper& acc=aset["value"];
             acc.collective_merge(comm_, root_);
+            // This is done by collective_merge(...):
             // if (!is_master) acc.reset();
         }
-    
+
         // Run again
         for (unsigned int i=0; i<NSTEPS; ++i) {
             aset["value"] << gen_();
@@ -94,7 +95,7 @@ class AccumulatorTest : public ::testing::Test {
             if (!aat::is_same_accumulator<accumulator_type,aa::MeanAccumulator>::value) {
                 EXPECT_NEAR(rset["test_value"].error<value_type>(), rset["value"].error<value_type>(), 1E-2) << "Error bar";
             }
-            
+
             if (aat::is_same_accumulator<accumulator_type,aa::LogBinningAccumulator>::value ||
                 aat::is_same_accumulator<accumulator_type,aa::FullBinningAccumulator>::value) {
                 EXPECT_NEAR(rset["test_value"].autocorrelation<value_type>(),
@@ -129,4 +130,4 @@ int main(int argc, char** argv)
    tweak(alps::mpi::communicator().rank(), argc, argv);
    ::testing::InitGoogleTest(&argc, argv);
    return RUN_ALL_TESTS();
-}    
+}


### PR DESCRIPTION
This restores changes by commit
9bd2ff220fe3540e3bc56c2c2c60fe5e41707bc0 ("Reset accumulators on
slaves after merging") which were apparently lost by merge commit
97d4b696ca4ec0ace8090fbf7aa4b7f9837ca0d1.

This should close #508.