### PR TITLE
Try to download Eigen3 using various methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
     -DCMAKE_CXX_COMPILER=${ALPS_CXX:-${CXX}}              \
     -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/installed    \
     -DALPS_INSTALL_EIGEN=true                             \
-    -DBUNDLE_DOWNLOAD_TRIES=3                             \
+    -DALPS_BUNDLE_DOWNLOAD_TRIES=3                        \
     -DMPIEXEC=mpiexec -DMPIEXEC_NUMPROC_FLAG='-n'         \
     -DENABLE_MPI=$ENABLE_MPI
   - make -j3

--- a/common/cmake/ALPSEnableEigen.cmake
+++ b/common/cmake/ALPSEnableEigen.cmake
@@ -12,6 +12,27 @@ if (NOT DEFINED BUNDLE_DOWNLOAD_TRIES)
   set(BUNDLE_DOWNLOAD_TRIES 1)
 endif()
 
+
+# Function to download Eigen using CMake file() built-in
+# Arguments:
+#  url      : URL to download
+#  destfile : where to download to
+#  ntries   : how many times to try
+#  statvar  : name of the variable to store status (0 == Success)
+function(cmake_download_ url destfile ntries statvar)
+  foreach(loop_var RANGE ${ntries})
+    file(DOWNLOAD ${url} ${destfile}
+      INACTIVITY_TIMEOUT 60
+      TIMEOUT 600
+      STATUS status
+      SHOW_PROGRESS)
+    if (status EQUAL 0)
+      break()
+    endif()
+  endforeach()
+  set(${statvar} ${status} PARENT_SCOPE)
+endfunction()
+
 # Add eigen to the current module (target ${PROJECT_NAME})
 # Sets EIGEN3_VERSION variable in the parent scope
 function(add_eigen)
@@ -78,17 +99,7 @@ function(add_eigen)
       message(STATUS "Trying to download and unpack Eigen3")
       if (NOT EXISTS "${ALPS_EIGEN_TGZ_FILE}")
         message(STATUS "Downloading Eigen3, timeout 600 sec")
-        # Attempt to download four times
-        foreach(loop_var RANGE ${BUNDLE_DOWNLOAD_TRIES})
-          file(DOWNLOAD ${ALPS_EIGEN_DOWNLOAD_LOCATION} ${ALPS_EIGEN_TGZ_FILE}
-            INACTIVITY_TIMEOUT 60
-            TIMEOUT 600
-            STATUS status_
-            SHOW_PROGRESS)
-          if (status_ EQUAL 0)
-            break()
-          endif()
-        endforeach()
+        cmake_download_(${ALPS_EIGEN_DOWNLOAD_LOCATION} ${ALPS_EIGEN_TGZ_FILE} ${BUNDLE_DOWNLOAD_TRIES} status_)
         if (status_ EQUAL 0)
           message(STATUS "Downloaded successfully")
         else()

--- a/common/cmake/ALPSEnableEigen.cmake
+++ b/common/cmake/ALPSEnableEigen.cmake
@@ -8,9 +8,9 @@ set(ALPS_EIGEN_DOWNLOAD_LOCATION "http://bitbucket.org/eigen/eigen/get/${ALPS_EI
     CACHE STRING "Eigen3 download location")
 mark_as_advanced(ALPS_EIGEN_DOWNLOAD_LOCATION)
 
-if (NOT DEFINED BUNDLE_DOWNLOAD_TRIES)
-  set(BUNDLE_DOWNLOAD_TRIES 1)
-endif()
+set(ALPS_BUNDLE_DOWNLOAD_TRIES 1 CACHE STRING "How many times to attempt a download of a dependency")
+mark_as_advanced(ALPS_BUNDLE_DOWNLOAD_TRIES)
+
 
 
 # Function to download Eigen using CMake file() built-in
@@ -99,7 +99,7 @@ function(add_eigen)
       message(STATUS "Trying to download and unpack Eigen3")
       if (NOT EXISTS "${ALPS_EIGEN_TGZ_FILE}")
         message(STATUS "Downloading Eigen3, timeout 600 sec")
-        cmake_download_(${ALPS_EIGEN_DOWNLOAD_LOCATION} ${ALPS_EIGEN_TGZ_FILE} ${BUNDLE_DOWNLOAD_TRIES} status_)
+        cmake_download_(${ALPS_EIGEN_DOWNLOAD_LOCATION} ${ALPS_EIGEN_TGZ_FILE} ${ALPS_BUNDLE_DOWNLOAD_TRIES} status_)
         if (status_ EQUAL 0)
           message(STATUS "Downloaded successfully")
         else()


### PR DESCRIPTION
The user can set `-DALPS_EIGEN_DOWNLOAD_METHODS` to a list of download methods to try, in the given order. Available methods are `cmake` (using CMake built-in `file`), `wget` (using `wget` utility, if available) and `curl` (using `curl` utility, if available). The default is `cmake;wget;curl`.

This should close #451.