### PR TITLE
Support for C++17

### DIFF
--- a/common/cmake/ALPSCompilerVersionCheck.cmake
+++ b/common/cmake/ALPSCompilerVersionCheck.cmake
@@ -25,42 +25,62 @@ else()
   endif()
 endif()
 
-
-
 unset(ALPS_CXX_STD) # ensure the var is read from cache, if any
 if (DEFINED ALPS_CXX_STD)
   if (ALPS_CXX_STD MATCHES "^[cC][+][+](03|98)$")
     unset(ALPS_CXX_STD CACHE)
     message(FATAL_ERROR "ALPSCore cannot be compiled with C++98/C++03; at least C++11 is required")
   endif()
-  if (NOT ALPS_CXX_STD MATCHES "^[cC][+][+](11|14)|custom$")
-    message(FATAL_ERROR "Invalid value of ALPS_CXX_STD='${ALPS_CXX_STD}'. Only 'c++11', 'c++14' and 'custom' are supported.")
+  if (NOT ALPS_CXX_STD MATCHES "^[cC][+][+](11|14|17)|custom$")
+    message(FATAL_ERROR "Invalid value of ALPS_CXX_STD='${ALPS_CXX_STD}'. Only 'c++11', 'c++14', 'c++17' and 'custom' are supported.")
   endif()
   string(TOLOWER ${ALPS_CXX_STD} ALPS_CXX_STD)
 else()
   set(ALPS_CXX_STD "c++11")
 endif()
 set(ALPS_CXX_STD ${ALPS_CXX_STD} CACHE STRING "C++ standard used to compile ALPSCore" FORCE)
-set_property(CACHE ALPS_CXX_STD PROPERTY STRINGS "c++11" "c++14" "custom")
+set_property(CACHE ALPS_CXX_STD PROPERTY STRINGS "c++11" "c++14" "c++17" "custom")
 mark_as_advanced(ALPS_CXX_STD)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# FIXME: In future we can try to set this ourselves if CMake does not recognize the compiler
+set(ALPS_CXX_FLAGS "" CACHE INTERNAL "C++ compilation flags to be set as interface")
+
 if (ALPS_CXX_STD STREQUAL "c++11")
-  set(ALPS_CXX_FEATURES "cxx_auto_type;cxx_constexpr" CACHE INTERNAL "List of C++ features required by ALPSCore")
-  set(ALPS_CXX_FLAGS "" CACHE INTERNAL "C++ compilation flags to be set as interface")
+  if (CMAKE_VERSION VERSION_LESS 3.8)
+    set(ALPS_CXX_FEATURES "cxx_auto_type;cxx_constexpr" CACHE INTERNAL "List of C++ features required by ALPSCore")
+  else()
+    # FIXME: if client uses cmake<3.8, this will lead to problems
+    set(ALPS_CXX_FEATURES "cxx_std_11" CACHE INTERNAL "List of C++ features required by ALPSCore")
+  endif()
   message(STATUS "ALPSCore will use C++11")
 endif()
 
 if (ALPS_CXX_STD STREQUAL "c++14")
-  set(ALPS_CXX_FEATURES "cxx_auto_type;cxx_constexpr;cxx_decltype_auto" CACHE INTERNAL "List of C++ features required by ALPSCore")
-  set(ALPS_CXX_FLAGS "" CACHE INTERNAL "C++ compilation flags to be set as interface")
+  if (CMAKE_VERSION VERSION_LESS 3.8)
+    set(ALPS_CXX_FEATURES "cxx_auto_type;cxx_constexpr;cxx_decltype_auto" CACHE INTERNAL "List of C++ features required by ALPSCore")
+  else()
+    # FIXME: if client uses cmake<3.8, this will lead to problems
+    set(ALPS_CXX_FEATURES "cxx_std_14" CACHE INTERNAL "List of C++ features required by ALPSCore")
+  endif()
   message(STATUS "ALPSCore will use C++14")
+endif()
+
+if (ALPS_CXX_STD STREQUAL "c++17")
+  if (CMAKE_VERSION VERSION_LESS 3.8)
+    message(FATAL_ERROR "To use ALPS_CXX_STD=c++17 you need at least CMake version 3.8; "
+      "this CMake version is ${CMAKE_VERSION}. "
+      "Please set ALPS_CXX_STD=custom and pass the proper compilation flags via CXX_COMPILE_FLAGS.")
+  else()
+    # FIXME: if client uses cmake<3.8, this will lead to problems
+    set(ALPS_CXX_FEATURES "cxx_std_17" CACHE INTERNAL "List of C++ features required by ALPSCore")
+  endif()
+  message(STATUS "ALPSCore will use C++17")
 endif()
 
 if (ALPS_CXX_STD STREQUAL "custom")
   set(ALPS_CXX_FEATURES "" CACHE INTERNAL "List of C++ features required by ALPSCore")
-  set(ALPS_CXX_FLAGS "" CACHE INTERNAL "C++ compilation flags to be set as interface")
   message("CAUTION: ALPSCore C++ standard will be set by compiler flags;"
     " client code will not have any way to inquire the C++ standard used by ALPSCore!")
 endif()

--- a/common/cmake/ALPSCompilerVersionCheck.cmake
+++ b/common/cmake/ALPSCompilerVersionCheck.cmake
@@ -46,12 +46,13 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # FIXME: In future we can try to set this ourselves if CMake does not recognize the compiler
 set(ALPS_CXX_FLAGS "" CACHE INTERNAL "C++ compilation flags to be set as interface")
+set(ALPS_CMAKE_MINIMUM_VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
 
 if (ALPS_CXX_STD STREQUAL "c++11")
   if (CMAKE_VERSION VERSION_LESS 3.8)
     set(ALPS_CXX_FEATURES "cxx_auto_type;cxx_constexpr" CACHE INTERNAL "List of C++ features required by ALPSCore")
   else()
-    # FIXME: if client uses cmake<3.8, this will lead to problems
+    set(ALPS_CMAKE_MINIMUM_VERSION 3.8)
     set(ALPS_CXX_FEATURES "cxx_std_11" CACHE INTERNAL "List of C++ features required by ALPSCore")
   endif()
   message(STATUS "ALPSCore will use C++11")
@@ -61,7 +62,7 @@ if (ALPS_CXX_STD STREQUAL "c++14")
   if (CMAKE_VERSION VERSION_LESS 3.8)
     set(ALPS_CXX_FEATURES "cxx_auto_type;cxx_constexpr;cxx_decltype_auto" CACHE INTERNAL "List of C++ features required by ALPSCore")
   else()
-    # FIXME: if client uses cmake<3.8, this will lead to problems
+    set(ALPS_CMAKE_MINIMUM_VERSION 3.8)
     set(ALPS_CXX_FEATURES "cxx_std_14" CACHE INTERNAL "List of C++ features required by ALPSCore")
   endif()
   message(STATUS "ALPSCore will use C++14")
@@ -73,7 +74,7 @@ if (ALPS_CXX_STD STREQUAL "c++17")
       "this CMake version is ${CMAKE_VERSION}. "
       "Please set ALPS_CXX_STD=custom and pass the proper compilation flags via CXX_COMPILE_FLAGS.")
   else()
-    # FIXME: if client uses cmake<3.8, this will lead to problems
+    set(ALPS_CMAKE_MINIMUM_VERSION 3.8)
     set(ALPS_CXX_FEATURES "cxx_std_17" CACHE INTERNAL "List of C++ features required by ALPSCore")
   endif()
   message(STATUS "ALPSCore will use C++17")
@@ -84,3 +85,5 @@ if (ALPS_CXX_STD STREQUAL "custom")
   message("CAUTION: ALPSCore C++ standard will be set by compiler flags;"
     " client code will not have any way to inquire the C++ standard used by ALPSCore!")
 endif()
+
+set(ALPS_CMAKE_MINIMUM_VERSION ${ALPS_CMAKE_MINIMUM_VERSION} CACHE INTERNAL "Minimum CMake version required to use ALPSCore")

--- a/common/cmake/ALPSCoreConfig.cmake.in
+++ b/common/cmake/ALPSCoreConfig.cmake.in
@@ -86,6 +86,16 @@ function(alpscore_config_main_)
 endfunction(alpscore_config_main_)
 
 
+set(ALPSCore_CMAKE_MINIMUM_VERSION @ALPS_CMAKE_MINIMUM_VERSION@)
+set(ALPSCore_CMAKE_MATCH true)
+if (CMAKE_VERSION VERSION_LESS ALPSCore_CMAKE_MINIMUM_VERSION)
+  message(WARNING "To use ALPScore CMake version ${ALPSCore_CMAKE_MINIMUM_VERSION} or later "
+    "is required; this CMake version is ${CMAKE_VERSION}. "
+    "You may use a newer CMake for your project, "
+    "or try to rebuild ALPSCore with CMake version ${CMAKE_VERSION}.")
+  set(ALPSCore_CMAKE_MATCH false)
+endif()
+    
 set(ALPSCore_HAS_MPI @ALPS_HAVE_MPI@)
 set(ALPSCore_CXX_STD "@ALPS_CXX_STD@")
 set(ALPSCore_CXX_COMPILER_ID "@CMAKE_CXX_COMPILER_ID@")
@@ -110,9 +120,9 @@ else()
     set(ALPSCore_COMPILER_MATCH false)
   endif()
 endif()
-if (ALPSCore_COMPILER_MATCH)
+if (ALPSCore_COMPILER_MATCH AND ALPSCore_CMAKE_MATCH)
   alpscore_config_main_()
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(ALPSCore REQUIRED_VARS ALPSCore_LIBRARIES ALPSCore_COMPILER_MATCH HANDLE_COMPONENTS)
+find_package_handle_standard_args(ALPSCore REQUIRED_VARS ALPSCore_LIBRARIES ALPSCore_COMPILER_MATCH ALPSCore_CMAKE_MATCH HANDLE_COMPONENTS)


### PR DESCRIPTION
Introduced support for C++17 (when using CMake 3.8+); verify if client should use newer CMake for their project. 
This should close #500.
