### PR TITLE
Change behavior of `origin_name(param)`

### DIFF
--- a/params/include/alps/params.hpp
+++ b/params/include/alps/params.hpp
@@ -159,8 +159,8 @@ namespace alps {
             /// Convenience method: returns the "origin name"
             /** @returns (parameter_file_name || restart_file name || program_name || "")
 
-                @deprecated Use `alps::params_ns::get_origin(const params&)` instead,
-                also available as `alps::get_origin(const params&)`.
+                @deprecated Use `alps::params_ns::origin_name(const params&)` instead,
+                also available as `alps::origin_name(const params&)`.
              **/
             std::string get_origin_name() const ALPS_DEPRECATED;
 
@@ -279,6 +279,20 @@ namespace alps {
             }
 #endif
         };
+
+        /// Convenience function to obtain the "origin" filename associated with the parameters object
+        /**
+           The "origin" name can be used to generate, e.g., sensible output file names
+           based on the parameter file names that passed to the program.
+
+           * * If the parameters object is restored from an archive, the archive name is its origin.
+           * * If the parameters object is constructed from INI file(s), the first INI file is its origin.
+           * * If the parameters object is constructed from the command line without INI files,
+             the origin is the executable name (if available) *stripped of its path*.
+           * * Otherwise, the origin name is empty.
+
+        */
+        std::string origin_name(const params& p);
 
     } // params_ns::
     typedef params_ns::params params;

--- a/params/include/alps/params/params_impl.hpp
+++ b/params/include/alps/params/params_impl.hpp
@@ -160,15 +160,6 @@ namespace alps {
             swap(p1.origins_.data(), p2.origins_.data());
         }
 
-        inline std::string origin_name(const params& p)
-        {
-            std::string origin;
-            if (p.is_restored()) origin=p.get_archive_name();
-            else if (p.get_ini_name_count()>0) origin=p.get_ini_name(0);
-            else origin=p.get_argv0();
-            return origin;
-        }
-
         inline std::string params::get_origin_name() const
         {
             return origin_name(*this);

--- a/params/src/params.cpp
+++ b/params/src/params.cpp
@@ -16,6 +16,8 @@
 #include <cstring> // for memcmp()
 #include <boost/optional.hpp>
 
+#include <alps/utilities/fs/get_basename.hpp>
+
 #include <alps/testing/fp_compare.hpp>
 
 // #include <alps/testing/unique_file.hpp> // FIXME!!! Temporary!
@@ -435,6 +437,14 @@ namespace alps {
             return s;
         }
 
+        std::string origin_name(const params& p)
+        {
+            std::string origin;
+            if (p.is_restored()) origin=p.get_archive_name();
+            else if (p.get_ini_name_count()>0) origin=p.get_ini_name(0);
+            else origin=alps::fs::get_basename(p.get_argv0());
+            return origin;
+        }
 
 #ifdef ALPS_HAVE_MPI
         void params::broadcast(const alps::mpi::communicator& comm, int rank) {

--- a/params/test/params_cmdline.cpp
+++ b/params/test/params_cmdline.cpp
@@ -5,7 +5,7 @@
  */
 
 /** @file params_cmdline.cpp
-    
+
     @brief Tests parameter input from commandline
 */
 
@@ -34,10 +34,10 @@ class ParamsTestCmdline : public ::testing::Test {
   public:
     ParamsTestCmdline() {}
 };
-    
+
 TEST_F(ParamsTestCmdline, argHolder) {
     ASSERT_EQ(1, args_.argc());
-    
+
     args_.add("arg1").add("arg2");
     ASSERT_EQ(3, args_.argc());
 
@@ -56,20 +56,6 @@ TEST_F(ParamsTestCmdline, iniMaker) {
     ostr << infile.rdbuf();
     EXPECT_EQ(std::string("line1\nline2\n"), ostr.str());
 }
-
-// TEST_F(ParamsTestCmdline, originName) {
-//     params p0;
-//     const params& cp0=p0;
-//     EXPECT_EQ("",cp0.get_origin_name());
-
-//     char** argv=0;
-//     int argc=0;
-//     params p1(argc, argv);
-//     EXPECT_EQ("", p1.get_origin_name());
-
-//     params p2(args_.argc(), args_.argv());
-//     EXPECT_EQ("./program_name", p2.get_origin_name());
-// }
 
 
 TEST_F(ParamsTestCmdline, filenameArgs) {
@@ -94,7 +80,7 @@ TEST_F(ParamsTestCmdline, filenameArgs) {
     EXPECT_EQ(1,p["one"]);
     EXPECT_EQ(2,p["two"]);
     EXPECT_EQ("three",p["three"]);
-}    
+}
 
 TEST_F(ParamsTestCmdline, boolFlagArgs) {
     args_
@@ -146,11 +132,11 @@ TEST_F(ParamsTestCmdline, filenamesAndKeys) {
         .add("one=111")    // overrides files even after it
         .add(ini1.name())  // partly overridden by cmdline before and after
         .add("two=222")    // overrides files
-        .add(ini2.name())  // partly overridden 
+        .add(ini2.name())  // partly overridden
         .add("three=333"); // overrides files
 
     params p(args_.argc(), args_.argv());
-    
+
     ASSERT_TRUE(p
                 .define<int>("zero", "Option 0")
                 .define<int>("one", "Option 1")
@@ -180,7 +166,7 @@ TEST_F(ParamsTestCmdline, doubleDash) {
 
     std::string ini1_as_key=ini1.name().substr(2);
     std::string ini2_as_key=ini2.name().substr(2);
-    
+
     ASSERT_TRUE(p
                 .define<int>("one", 0, "Option 1")
                 .define<int>("two", 0, "Option 2")

--- a/params/test/params_origins.cpp
+++ b/params/test/params_origins.cpp
@@ -5,7 +5,7 @@
  */
 
 /** @file params_origins.cpp
-    
+
     @brief Tests parameter origin query methods
 */
 
@@ -25,14 +25,14 @@ TEST(ParamsTestOrigins, simple) {
 }
 
 TEST(ParamsTestOrigins, cmdlineOnly) {
-    arg_holder args("./progname");
+    arg_holder args("path/to/progname.exe");
     args.add("some=string");
     alps::params p(args.argc(), args.argv());
-    EXPECT_EQ("./progname", p.get_argv0());
+    EXPECT_EQ("path/to/progname.exe", p.get_argv0());
     EXPECT_EQ(0, p.get_ini_name_count());
     ASSERT_NO_THROW(p.get_ini_name(0));
     EXPECT_TRUE(p.get_ini_name(0).empty());
-    EXPECT_EQ("./progname",origin_name(p));
+    EXPECT_EQ("progname.exe",origin_name(p));
 }
 
 TEST(ParamsTestOrigins, inifileOnly) {
@@ -54,13 +54,13 @@ TEST(ParamsTestOrigins, inifileInCmdline) {
     ini_maker ini2("params_origins2.ini.");
     ini2.add("another=string2");
 
-    arg_holder args("./progname");
+    arg_holder args("path/to/progname.exe");
     args.add(ini1.name());
     args.add("some_other=string3");
     args.add(ini2.name());
-    
+
     alps::params p(args.argc(), args.argv());
-    EXPECT_EQ("./progname", p.get_argv0());
+    EXPECT_EQ("path/to/progname.exe", p.get_argv0());
     EXPECT_EQ(2, p.get_ini_name_count());
 
     ASSERT_NO_THROW(p.get_ini_name(0));
@@ -68,7 +68,7 @@ TEST(ParamsTestOrigins, inifileInCmdline) {
 
     ASSERT_NO_THROW(p.get_ini_name(1));
     EXPECT_EQ(ini2.name(), p.get_ini_name(1));
-    
+
     ASSERT_NO_THROW(p.get_ini_name(2));
     EXPECT_TRUE(p.get_ini_name(2).empty());
 


### PR DESCRIPTION
If the parameters object `p` is created from a command line without
any INI files, `origin_name(p)` now returns the program executable
name *with path stripped* (that is, the basename).

This closes #285.
