### PR TITLE
removing boost::shared_ptr and replacing it with std::shared_ptr

### DIFF
--- a/accumulators/include/alps/accumulators/accumulator.hpp
+++ b/accumulators/include/alps/accumulators/accumulator.hpp
@@ -15,7 +15,7 @@
 
 #include <alps/hdf5/archive.hpp>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <boost/variant/variant.hpp>
 #include <boost/variant/get.hpp>
@@ -35,7 +35,7 @@ namespace alps {
             typedef std::string printable_type; ///<Implementation-defined printable type for results/accumulators
 
             template<typename T> struct add_base_wrapper_pointer {
-                typedef boost::shared_ptr<base_wrapper<T> > type;
+                typedef std::shared_ptr<base_wrapper<T> > type;
             };
 
             template<typename... Types> struct make_variant_type {
@@ -64,7 +64,7 @@ namespace alps {
             /** @note Throws on a failed check */
             // FIXME: better initialize the pointer with something reasonable to begin with?
             template <typename T>
-            void check_ptr(const boost::shared_ptr<T>& ptr) {
+            void check_ptr(const std::shared_ptr<T>& ptr) {
                 if (!ptr) throw std::runtime_error("Uninitialized accumulator accessed");
             }
 
@@ -96,7 +96,7 @@ namespace alps {
                 result_wrapper(hdf5::archive & ar);
 
                 // operator=
-                result_wrapper & operator=(boost::shared_ptr<result_wrapper> const & rhs);
+                result_wrapper & operator=(std::shared_ptr<result_wrapper> const & rhs);
 
             private:
                 // Visitors that need access to m_variant
@@ -461,7 +461,7 @@ namespace alps {
                 accumulator_wrapper* new_clone() const;
 
                 // operator=
-                accumulator_wrapper & operator=(boost::shared_ptr<accumulator_wrapper> const & rhs);
+                accumulator_wrapper & operator=(std::shared_ptr<accumulator_wrapper> const & rhs);
 
                 // count
                 boost::uint64_t count() const;
@@ -539,7 +539,7 @@ namespace alps {
             void reset() const;
 
             // result
-            boost::shared_ptr<result_wrapper> result() const;
+            std::shared_ptr<result_wrapper> result() const;
 
             // print
             void print(std::ostream & os, bool terse=false) const;

--- a/accumulators/include/alps/accumulators/feature/weight_holder.hpp
+++ b/accumulators/include/alps/accumulators/feature/weight_holder.hpp
@@ -16,7 +16,7 @@
 #include <alps/utilities/short_print.hpp>
 
 #include <boost/utility.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <stdexcept>
 #include <type_traits>
@@ -137,7 +137,7 @@ namespace alps {
 
                 private:
                     bool m_owner;
-                    boost::shared_ptr< ::alps::accumulators::base_wrapper<typename value_type<weight_type>::type> > m_weight;
+                    std::shared_ptr< ::alps::accumulators::base_wrapper<typename value_type<weight_type>::type> > m_weight;
             };
 
             template<typename T, typename W, typename B> class Result<T, weight_holder_tag<W>, B> : public B {
@@ -192,7 +192,7 @@ namespace alps {
 
                 protected:
                     bool m_owner;
-                    boost::shared_ptr< ::alps::accumulators::base_wrapper<typename value_type<weight_type>::type> > m_weight;
+                    std::shared_ptr< ::alps::accumulators::base_wrapper<typename value_type<weight_type>::type> > m_weight;
             };
 
         }

--- a/accumulators/include/alps/accumulators/namedaccumulators.hpp
+++ b/accumulators/include/alps/accumulators/namedaccumulators.hpp
@@ -30,7 +30,7 @@ namespace alps {
                 AccumulatorBase(const ArgumentPack& rhs,
                                 typename std::enable_if<std::is_base_of<AccumulatorBase,ArgumentPack>::value,int>::type =0)
                     : name(rhs.name),
-                      wrapper(boost::shared_ptr<accumulator_wrapper>(rhs.wrapper->new_clone()))
+                      wrapper(std::shared_ptr<accumulator_wrapper>(rhs.wrapper->new_clone()))
                 { }
 
                 /// Adds value directly to this named accumulator
@@ -42,7 +42,7 @@ namespace alps {
                 }
 
                 /// Returns a shared pointer to the result associated with this named accumulator
-                boost::shared_ptr<result_wrapper> result() const
+                std::shared_ptr<result_wrapper> result() const
                 {
                     return wrapper->result();
                 }
@@ -52,7 +52,7 @@ namespace alps {
                 {
                     // Self-assignment is handled correctly (albeit inefficiently)
                     this->name=rhs.name;
-                    this->wrapper = boost::shared_ptr<accumulator_wrapper>(rhs.wrapper->new_clone());
+                    this->wrapper = std::shared_ptr<accumulator_wrapper>(rhs.wrapper->new_clone());
                     return *this;
                 }
 
@@ -66,7 +66,7 @@ namespace alps {
 #endif
 
                 std::string name;
-                boost::shared_ptr<accumulator_wrapper> wrapper;
+                std::shared_ptr<accumulator_wrapper> wrapper;
             }; // end struct AccumulatorBase
         } // end namespace detail
 

--- a/accumulators/include/alps/accumulators/wrapper_set.hpp
+++ b/accumulators/include/alps/accumulators/wrapper_set.hpp
@@ -9,7 +9,7 @@
 #include <alps/config.hpp>
 #include <alps/hdf5/archive.hpp>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <mutex>
 
 namespace alps {
@@ -29,8 +29,8 @@ namespace alps {
                 public:
                     typedef T value_type;
 
-                    typedef typename std::map<std::string, boost::shared_ptr<T> >::iterator iterator;
-                    typedef typename std::map<std::string, boost::shared_ptr<T> >::const_iterator const_iterator;
+                    typedef typename std::map<std::string, std::shared_ptr<T> >::iterator iterator;
+                    typedef typename std::map<std::string, std::shared_ptr<T> >::const_iterator const_iterator;
 
                     // TODO: make trait ... to disable for result_wrapper
                     template <typename U> wrapper_set(wrapper_set<U> const & arg) {
@@ -46,7 +46,7 @@ namespace alps {
 
                     bool has(std::string const & name) const;
 
-                    void insert(std::string const & name, boost::shared_ptr<T> ptr);
+                    void insert(std::string const & name, std::shared_ptr<T> ptr);
 
                     std::size_t size() const {
                         return m_storage.size();
@@ -94,11 +94,11 @@ namespace alps {
                     }
 
                 private:
-                    std::map<std::string, boost::shared_ptr<T> > m_storage;
-                    static std::vector<boost::shared_ptr<detail::serializable_type<T> > > m_types;
+                    std::map<std::string, std::shared_ptr<T> > m_storage;
+                    static std::vector<std::shared_ptr<detail::serializable_type<T> > > m_types;
                     static std::mutex m_types_mutex;
             };
-            template<typename T> std::vector<boost::shared_ptr<detail::serializable_type<T> > > wrapper_set<T>::m_types;
+            template<typename T> std::vector<std::shared_ptr<detail::serializable_type<T> > > wrapper_set<T>::m_types;
             template<typename T> std::mutex wrapper_set<T>::m_types_mutex;
 
             template<typename T> inline std::ostream & operator<<(std::ostream & os, const wrapper_set<T> & arg) {

--- a/accumulators/include/alps/accumulators_.hpp
+++ b/accumulators/include/alps/accumulators_.hpp
@@ -125,7 +125,7 @@ namespace alps {
                     /// Merge another accumulator into this one. @param rhs  accumulator to merge.
                     void merge(const virtual_accumulator_wrapper & rhs);
 
-                    virtual_accumulator_wrapper & operator=(boost::shared_ptr<virtual_accumulator_wrapper> const & rhs);
+                    virtual_accumulator_wrapper & operator=(std::shared_ptr<virtual_accumulator_wrapper> const & rhs);
 
                     // count
                     boost::uint64_t count() const;
@@ -164,7 +164,7 @@ namespace alps {
                     void reset() const;
 
                     // result
-                    boost::shared_ptr<virtual_result_wrapper<virtual_accumulator_wrapper> > result() const;
+                    std::shared_ptr<virtual_result_wrapper<virtual_accumulator_wrapper> > result() const;
 
                     // print
                     void print(std::ostream & os) const;

--- a/accumulators/src/accumulator_wrapper.cpp
+++ b/accumulators/src/accumulator_wrapper.cpp
@@ -94,7 +94,7 @@ namespace alps {
             }
             mutable accumulator_wrapper * self;
         };
-        accumulator_wrapper & accumulator_wrapper::operator=(boost::shared_ptr<accumulator_wrapper> const & rhs) {
+        accumulator_wrapper & accumulator_wrapper::operator=(std::shared_ptr<accumulator_wrapper> const & rhs) {
             boost::apply_visitor(assign_visitor(this), rhs->m_variant);
             return *this;
         }
@@ -167,11 +167,11 @@ namespace alps {
         struct result_visitor: public boost::static_visitor<> {
             template<typename T> void operator()(T const & arg) {
                 detail::check_ptr(arg);
-                value = boost::shared_ptr<result_wrapper>(new result_wrapper(arg->result()));
+                value = std::shared_ptr<result_wrapper>(new result_wrapper(arg->result()));
             }
-            boost::shared_ptr<result_wrapper> value;
+            std::shared_ptr<result_wrapper> value;
         };
-        boost::shared_ptr<result_wrapper> accumulator_wrapper::result() const {
+        std::shared_ptr<result_wrapper> accumulator_wrapper::result() const {
             result_visitor visitor;
             boost::apply_visitor(visitor, m_variant);
             return visitor.value;

--- a/accumulators/src/accumulators.cpp
+++ b/accumulators/src/accumulators.cpp
@@ -132,7 +132,7 @@ namespace alps {
             	m_ptr->merge(*(rhs.m_ptr));
             }
 
-            virtual_accumulator_wrapper & virtual_accumulator_wrapper::operator=(boost::shared_ptr<virtual_accumulator_wrapper> const & rhs){
+            virtual_accumulator_wrapper & virtual_accumulator_wrapper::operator=(std::shared_ptr<virtual_accumulator_wrapper> const & rhs){
             	(*m_ptr) = *(rhs->m_ptr);
             	return *this;
             }
@@ -174,8 +174,8 @@ namespace alps {
             }
 
             // result
-            boost::shared_ptr<virtual_result_wrapper<virtual_accumulator_wrapper> > virtual_accumulator_wrapper::result() const {
-                return boost::shared_ptr<virtual_result_wrapper<virtual_accumulator_wrapper> >(
+            std::shared_ptr<virtual_result_wrapper<virtual_accumulator_wrapper> > virtual_accumulator_wrapper::result() const {
+                return std::shared_ptr<virtual_result_wrapper<virtual_accumulator_wrapper> >(
                     new virtual_result_wrapper<virtual_accumulator_wrapper>(new result_wrapper(*(m_ptr->result())))
                 );
             }
@@ -199,7 +199,7 @@ namespace alps {
 
     #define ALPS_ACCUMULATOR_ADD_ACCUMULATOR(r, type, T)                                                                \
         accumulator_set & operator<<(accumulator_set & set, const MeanAccumulator< T > & arg) {                         \
-            set.insert(arg.name(), boost::shared_ptr<accumulators::wrapped::virtual_accumulator_wrapper>(               \
+            set.insert(arg.name(), std::shared_ptr<accumulators::wrapped::virtual_accumulator_wrapper>(               \
                 new accumulators::wrapped::virtual_accumulator_wrapper(new accumulators::accumulator_wrapper(           \
                     accumulators::impl::Accumulator<                                                                    \
                         T , accumulators::mean_tag, accumulators::impl::Accumulator<                                    \
@@ -211,7 +211,7 @@ namespace alps {
             return set;                                                                                                 \
         }                                                                                                               \
         accumulator_set & operator<<(accumulator_set & set, const NoBinningAccumulator< T > & arg) {                    \
-            set.insert(arg.name(), boost::shared_ptr<accumulators::wrapped::virtual_accumulator_wrapper>(               \
+            set.insert(arg.name(), std::shared_ptr<accumulators::wrapped::virtual_accumulator_wrapper>(               \
                 new accumulators::wrapped::virtual_accumulator_wrapper(new accumulators::accumulator_wrapper(           \
                     accumulators::impl::Accumulator<                                                                    \
                         T , accumulators::error_tag, accumulators::impl::Accumulator<                                   \
@@ -225,7 +225,7 @@ namespace alps {
             return set;                                                                                                 \
         }                                                                                                               \
         accumulator_set & operator<<(accumulator_set & set, const LogBinningAccumulator< T > & arg) {                    \
-            set.insert(arg.name(), boost::shared_ptr<accumulators::wrapped::virtual_accumulator_wrapper>(               \
+            set.insert(arg.name(), std::shared_ptr<accumulators::wrapped::virtual_accumulator_wrapper>(               \
                 new accumulators::wrapped::virtual_accumulator_wrapper(new accumulators::accumulator_wrapper(           \
                     accumulators::impl::Accumulator<                                                                    \
                         T , accumulators::binning_analysis_tag, accumulators::impl::Accumulator<                        \
@@ -241,7 +241,7 @@ namespace alps {
             return set;                                                                                                 \
         }                                                                                                               \
         accumulator_set & operator<<(accumulator_set & set, const FullBinningAccumulator< T > & arg) {                    \
-            set.insert(arg.name(), boost::shared_ptr<accumulators::wrapped::virtual_accumulator_wrapper>(               \
+            set.insert(arg.name(), std::shared_ptr<accumulators::wrapped::virtual_accumulator_wrapper>(               \
                 new accumulators::wrapped::virtual_accumulator_wrapper(new accumulators::accumulator_wrapper(           \
                     accumulators::impl::Accumulator<                                                                    \
                         T , accumulators::max_num_binning_tag, accumulators::impl::Accumulator<                         \

--- a/accumulators/src/result_wrapper.cpp
+++ b/accumulators/src/result_wrapper.cpp
@@ -46,7 +46,7 @@ namespace alps {
             }
             mutable result_wrapper * self;
         };
-        result_wrapper & result_wrapper::operator=(boost::shared_ptr<result_wrapper> const & rhs) {
+        result_wrapper & result_wrapper::operator=(std::shared_ptr<result_wrapper> const & rhs) {
             boost::apply_visitor(assign_visitor(this), rhs->m_variant);
             return *this;
         }

--- a/accumulators/src/wrapper_set.cpp
+++ b/accumulators/src/wrapper_set.cpp
@@ -27,7 +27,7 @@ namespace alps {
             template<typename T>
             T & wrapper_set<T>::operator[](std::string const & name) {
                 if (!has(name))
-                    m_storage.insert(make_pair(name, boost::shared_ptr<T>(new T())));
+                    m_storage.insert(make_pair(name, std::shared_ptr<T>(new T())));
                 return *(m_storage.find(name)->second);
             }
 
@@ -44,7 +44,7 @@ namespace alps {
             }
 
             template<typename T>
-            void wrapper_set<T>::insert(std::string const & name, boost::shared_ptr<T> ptr){
+            void wrapper_set<T>::insert(std::string const & name, std::shared_ptr<T> ptr){
                 if (has(name))
                     throw std::out_of_range("There already exists an accumulator with the name: " + name + ALPS_STACKTRACE);
                 m_storage.insert(make_pair(name, ptr));

--- a/accumulators/src/wrapper_set_hdf5.cpp
+++ b/accumulators/src/wrapper_set_hdf5.cpp
@@ -45,7 +45,7 @@ namespace alps {
         namespace impl {
             /// Register a serializable type, without locking
             template<typename T> template<typename A> void wrapper_set<T>::register_serializable_type_nolock() {
-                m_types.push_back(boost::shared_ptr<detail::serializable_type<T> >(new detail::serializable_type_impl<T, A>));
+                m_types.push_back(std::shared_ptr<detail::serializable_type<T> >(new detail::serializable_type_impl<T, A>));
                 for (std::size_t i = m_types.size(); i > 1 && m_types[i - 1]->rank() > m_types[i - 2]->rank(); --i)
                     m_types[i - 1].swap(m_types[i - 2]);
             }
@@ -95,12 +95,12 @@ namespace alps {
                 std::vector<std::string> list = ar.list_children("");
                 for (std::vector<std::string>::const_iterator it = list.begin(); it != list.end(); ++it) {
                     ar.set_context(*it);
-                    for (typename std::vector<boost::shared_ptr<detail::serializable_type<T> > >::const_iterator jt = m_types.begin()
+                    for (typename std::vector<std::shared_ptr<detail::serializable_type<T> > >::const_iterator jt = m_types.begin()
                         ; jt != m_types.end()
                         ; ++jt
                     )
                         if ((*jt)->can_load(ar)) {
-                            operator[](*it) = boost::shared_ptr<T>((*jt)->create(ar));
+                            operator[](*it) = std::shared_ptr<T>((*jt)->create(ar));
                             break;
                         }
                     if (!has(*it))

--- a/accumulators/test/binop_mixed.cpp
+++ b/accumulators/test/binop_mixed.cpp
@@ -51,7 +51,7 @@ class AccumulatorMixedBinaryTest : public ::testing::Test {
     // double exp_scalar_right_err_;
 
     aa::accumulator_set aset_;
-    boost::shared_ptr<aa::result_set> rset_p_;
+    std::shared_ptr<aa::result_set> rset_p_;
 
     aa::result_set& results() {
         return *rset_p_;
@@ -71,7 +71,7 @@ class AccumulatorMixedBinaryTest : public ::testing::Test {
             aset_["left"] << aat::gen_data<value_type>(v).value();
             aset_["right"] << aat::gen_data<value_type>(v).value();
         }
-        rset_p_=boost::shared_ptr<aa::result_set>(new aa::result_set(aset_));
+        rset_p_=std::shared_ptr<aa::result_set>(new aa::result_set(aset_));
 
         exp_scalar_left_mean_=scalar_gen_.mean(NPOINTS);
         exp_scalar_right_mean_=exp_scalar_left_mean_;

--- a/accumulators/test/get_results.cpp
+++ b/accumulators/test/get_results.cpp
@@ -22,7 +22,7 @@ class AccumulatorTest : public ::testing::Test {
             measurements["one_half"]<<0.5;
         }
 
-        boost::shared_ptr<alps::accumulators::result_wrapper> res=measurements["one_half"].result();
+        std::shared_ptr<alps::accumulators::result_wrapper> res=measurements["one_half"].result();
         value_type xmean=res->mean<value_type>();
 
         EXPECT_NEAR(value_type(0.5), xmean, 1E-8);

--- a/accumulators/test/mpi_merge.cpp
+++ b/accumulators/test/mpi_merge.cpp
@@ -115,7 +115,7 @@ class AccumulatorTest : public ::testing::Test {
 
         if (comm.rank()==0) { // the accumulator is valid only on master
             // extract results
-            const boost::shared_ptr<alps::accumulators::result_wrapper> resptr=acc.result();
+            const std::shared_ptr<alps::accumulators::result_wrapper> resptr=acc.result();
 
             // test results
             int ntot=std::accumulate(nsamples.begin(), nsamples.end(), 0);

--- a/accumulators/test/mpi_merge_uneven.cpp
+++ b/accumulators/test/mpi_merge_uneven.cpp
@@ -58,7 +58,7 @@ class AccumulatorTest : public ::testing::Test {
         acc.collective_merge(comm, master);
         if (master==rank) {
             // extract results
-            const boost::shared_ptr<aac::result_wrapper> resptr=acc.result();
+            const std::shared_ptr<aac::result_wrapper> resptr=acc.result();
             const aac::result_wrapper& res=*resptr;
 
             value_type expected_mean=aact::gen_data<value_type>(gen.mean(npoints_all), VECSIZE);

--- a/accumulators/test/single_accumulator.cpp
+++ b/accumulators/test/single_accumulator.cpp
@@ -34,11 +34,11 @@ class SingleAccumulatorTest : public ::testing::Test {
     {
         using namespace alps::accumulators;
         named_acc_type named_acc("accname");
-        boost::shared_ptr<accumulator_wrapper> awptr=named_acc.wrapper;
+        std::shared_ptr<accumulator_wrapper> awptr=named_acc.wrapper;
         accumulator_wrapper& aw=*awptr;
         aw << 1.0;
 
-        boost::shared_ptr<result_wrapper> resptr=awptr->result();
+        std::shared_ptr<result_wrapper> resptr=awptr->result();
         result_wrapper& res=*resptr;
         // This is wrong:
         // result_wrapper& res=*(awptr->result());

--- a/accumulators/test/zero_vector_mpi.cpp
+++ b/accumulators/test/zero_vector_mpi.cpp
@@ -36,7 +36,7 @@ class AccumulatorEmptyVecTest : public ::testing::Test {
 
     void add_data_test() {
         EXPECT_ANY_THROW(acc_ << value_type());
-        boost::shared_ptr<aa::result_wrapper> resptr=acc_.result();
+        std::shared_ptr<aa::result_wrapper> resptr=acc_.result();
         EXPECT_EQ(0u, resptr->count());
     }
 

--- a/utilities/include/alps/utilities/mpi.hpp
+++ b/utilities/include/alps/utilities/mpi.hpp
@@ -26,7 +26,7 @@
 #include <algorithm> /* for std::max */
 
 #include <boost/scoped_array.hpp> /* for std::string broadcast */
-#include <boost/shared_ptr.hpp> /* for proper copy/assign of managed communicators */
+#include <memory> /* for proper copy/assign of managed communicators */
 
 #include <stdexcept>
 #include <typeinfo>
@@ -98,7 +98,7 @@ namespace alps {
 
         /// Encapsulation of an MPI communicator and some communicator-related operations
         class communicator {
-            boost::shared_ptr<MPI_Comm> comm_ptr_;
+            std::shared_ptr<MPI_Comm> comm_ptr_;
 
             // Internal functor class to destroy communicator when needed
             struct comm_deleter {

--- a/utilities/test/unique_file.cpp
+++ b/utilities/test/unique_file.cpp
@@ -6,7 +6,7 @@
 
 #include <fstream>
 #include <alps/testing/unique_file.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <map>
 
 #include <gtest/gtest.h>
@@ -96,7 +96,7 @@ TEST(TemporaryFile, CheckClash)
     const std::string prefix="alps_temp_filename_test";
     const unsigned int n_uniq_names=(1<<10); // how many uniq names to create
 
-    typedef boost::shared_ptr<at::unique_file> ufile_ptr;
+    typedef std::shared_ptr<at::unique_file> ufile_ptr;
     typedef std::map<std::string,ufile_ptr> map_type;
     typedef map_type::value_type val_type;
     typedef map_type::iterator iter_type;


### PR DESCRIPTION
This is a modernization effort inspired by one of Sergei's commits: replacing boost::shared_ptr by std::shared_ptr.