### PR TITLE
Striving for warning-free compilation

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,20 +2,20 @@
     "license": "other-open", 
     "creators": [
         {
-            "affiliation": "University of Michigan, Ann Arbor, MI, USA", 
-            "name": "Alexander Gaenko"
+            "name": "Alexander Gaenko",
+            "affiliation": "University of Michigan, Ann Arbor, MI, USA"
         }, 
         {
-            "affiliation": "University of Michigan, Ann Arbor, MI, USA",
-            "name": "Andrey E. Antipov"
+            "name": "Andrey E. Antipov",
+            "affiliation": "University of Michigan, Ann Arbor, MI, USA"
         }, 
         {
             "name": "Gabriele Carcassi",
             "affiliation": "University of Michigan, Ann Arbor, MI, USA"
         }, 
         {
-            "affiliation": "ETH Zurich, Zurich, Switzerland",
-            "name": "Lukas Gamper"
+            "name": "Lukas Gamper",
+            "affiliation": "ETH Zurich, Zurich, Switzerland"
         }, 
         {
             "name": "Tianran Chen",
@@ -46,12 +46,24 @@
             "affiliation": "ETH Zurich, Zurich, Switzerland"
         }, 
         {
+            "name": "Joseph Kleinhenz",
+            "affiliation": "University of Michigan, Ann Arbor, MI, USA"
+        }, 
+        {
+          "name": "Igor Krivenko",
+          "affiliation": "University of Michigan, Ann Arbor, MI, USA"
+        }, 
+        {
             "name": "James P.F. LeBlanc",
             "affiliation": "Memorial University of Newfoundland, Newfoundland & Labrador, Canada"
         },
         {
             "name": "Ryan Levy",
             "affiliation": "University of Illinois, Urbana-Champaign, IL, USA"
+        }, 
+        {
+            "name": "Jia Li",
+            "affiliation": "University of Michigan, Ann Arbor, MI, USA"
         }, 
         {
             "name": "Tama Ma",
@@ -74,8 +86,12 @@
             "affiliation": "ETH Zurich, Zurich, Switzerland"
         }, 
         {
-            "affiliation": "University of Michigan, Ann Arbor, MI, USA", 
-            "name": "Emanuel Gull"
+            "name": "Markus Wallerberger",
+            "affiliation": "University of Michigan, Ann Arbor, MI, USA"
+        }, 
+        {
+            "name": "Emanuel Gull",
+            "affiliation": "University of Michigan, Ann Arbor, MI, USA"
         }
     ], 
     "access_right": "open", 

--- a/accumulators/include/alps/accumulators/feature.hpp
+++ b/accumulators/include/alps/accumulators/feature.hpp
@@ -206,7 +206,7 @@ namespace alps {
 #endif
             };
 
-            template<typename T, typename F, typename B> struct Accumulator {};
+            template<typename T, typename F, typename B> class Accumulator {};
 
             template<typename T, typename F, typename B> class Result {};
 

--- a/common/build/build.travis.sh
+++ b/common/build/build.travis.sh
@@ -16,6 +16,13 @@ if [ -n "$ALPS_BOOST_VERSION" ]; then
   boost_cmake_params="-DBoost_NO_SYSTEM_PATHS=true -DBoost_NO_BOOST_CMAKE=true -DBOOST_ROOT=$download_dir/boost_${ALPS_BOOST_VERSION}"
 fi
 
+# FIXME: A hack to suppress warnings in MPI headers
+mpi_warning_hack=""
+if [[ "$ENABLE_MPI" == "ON" ]]; then
+    mpi_incdirs=" $(mpic++ -showme:incdirs)"
+    mpi_warning_hack="${mpi_incdirs// / -isystem }"
+fi
+
 # Build ALPSCore
 mkdir -pv build
 mkdir -pv install
@@ -24,7 +31,7 @@ cmake ..                                              \
 -DCMAKE_BUILD_TYPE=Debug                              \
 -DCMAKE_C_COMPILER=${ALPS_CC:-${CC}}                  \
 -DALPS_CXX_STD=$ALPS_CXX_STD                          \
--DCMAKE_CXX_FLAGS='-Wall -Werror'                     \
+-DCMAKE_CXX_FLAGS="-Wall -Werror ${mpi_warning_hack}"   \
 -DCMAKE_CXX_COMPILER=${ALPS_CXX:-${CXX}}              \
 -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/installed    \
 -DALPS_INSTALL_EIGEN=true                             \

--- a/common/build/build.travis.sh
+++ b/common/build/build.travis.sh
@@ -31,7 +31,7 @@ cmake ..                                              \
 -DCMAKE_BUILD_TYPE=Debug                              \
 -DCMAKE_C_COMPILER=${ALPS_CC:-${CC}}                  \
 -DALPS_CXX_STD=$ALPS_CXX_STD                          \
--DCMAKE_CXX_FLAGS="-Wall -Werror ${mpi_warning_hack}"   \
+-DCMAKE_CXX_FLAGS="-Wall -Wno-missing-braces -Wmissing-field-initializers -Werror ${mpi_warning_hack}"   \
 -DCMAKE_CXX_COMPILER=${ALPS_CXX:-${CXX}}              \
 -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/installed    \
 -DALPS_INSTALL_EIGEN=true                             \

--- a/common/build/build.travis.sh
+++ b/common/build/build.travis.sh
@@ -24,6 +24,7 @@ cmake ..                                              \
 -DCMAKE_BUILD_TYPE=Debug                              \
 -DCMAKE_C_COMPILER=${ALPS_CC:-${CC}}                  \
 -DALPS_CXX_STD=$ALPS_CXX_STD                          \
+-DCMAKE_CXX_FLAGS='-Wall -Werror'                     \
 -DCMAKE_CXX_COMPILER=${ALPS_CXX:-${CXX}}              \
 -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/installed    \
 -DALPS_INSTALL_EIGEN=true                             \

--- a/common/cmake/ALPSEnableTests.cmake
+++ b/common/cmake/ALPSEnableTests.cmake
@@ -13,7 +13,15 @@ function(UseGtest gtest_root)
 
     message(STATUS "gtest is in ${gtest_root}")
     if (NOT TARGET ${gtest_root})
+        # Hack to suppress all warnings in gtest
+        set(save_cxx_flags_ ${CMAKE_CXX_FLAGS})
+        set(save_c_flags_ ${CMAKE_C_FLAGS})
+        # FIXME: this is actually gcc/clang/icc specific
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
         add_subdirectory(${gtest_root} ${PROJECT_BINARY_DIR}/gtest)
+        set(CMAKE_CXX_FLAGS ${save_cxx_flags_})
+        set(CMAKE_C_FLAGS ${save_c_flags_})
     endif()
             
     # export gtest variables
@@ -36,7 +44,7 @@ if (NOT tests_are_already_enabled)
     unset(gtest_root)
     find_package(GTest)
     # set (LINK_TEST  ${GTEST_MAIN_LIBRARIES}) 
-    include_directories(${GTEST_INCLUDE_DIRS})
+    include_directories(SYSTEM ${GTEST_INCLUDE_DIRS})
     set(tests_are_already_enabled TRUE)
 endif(NOT tests_are_already_enabled)
 

--- a/utilities/test/tensor_test.cpp
+++ b/utilities/test/tensor_test.cpp
@@ -497,9 +497,9 @@ TEST(TensorTest, ValueAssignment) {
   int value = 5;
   X.set_number(value);
   Z.set_number(value);
-  for(int i = 0; i<N; ++i){
-    for (int j = 0; j < N; ++j) {
-      for (int k = 0; k < N; ++k) {
+  for(size_t i = 0; i<N; ++i){
+    for (size_t j = 0; j < N; ++j) {
+      for (size_t k = 0; k < N; ++k) {
         ASSERT_EQ(X(i,j,k), value);
         ASSERT_EQ(Z(i,j,k), std::complex<double>(value));
       }
@@ -507,9 +507,9 @@ TEST(TensorTest, ValueAssignment) {
   }
   X.set_zero();
   Z.set_zero();
-  for(int i = 0; i<N; ++i){
-    for (int j = 0; j < N; ++j) {
-      for (int k = 0; k < N; ++k) {
+  for(size_t i = 0; i<N; ++i){
+    for (size_t j = 0; j < N; ++j) {
+      for (size_t k = 0; k < N; ++k) {
         ASSERT_EQ(X(i,j,k), 0.0);
         ASSERT_EQ(Z(i,j,k), std::complex<double>(0.0));
       }
@@ -520,9 +520,9 @@ TEST(TensorTest, ValueAssignment) {
 TEST(TensorTest, Negate) {
   size_t N = 10;
   tensor <double, 3> X(N, N, N);
-  for(int i = 0; i<N; ++i){
-    for (int j = 0; j < N; ++j) {
-      for (int k = 0; k < N; ++k) {
+  for(size_t i = 0; i<N; ++i){
+    for (size_t j = 0; j < N; ++j) {
+      for (size_t k = 0; k < N; ++k) {
         X(i,j,k) = double(i*N + j*N*N + k)/double(N*N);
       }
     }
@@ -530,9 +530,9 @@ TEST(TensorTest, Negate) {
   tensor <double, 3> Y = -X;
   tensor<std::complex<double>, 3> Z = -Y;
   tensor<float, 3> W = -X;
-  for(int i = 0; i<N; ++i){
-    for (int j = 0; j < N; ++j) {
-      for (int k = 0; k < N; ++k) {
+  for(size_t i = 0; i<N; ++i){
+    for (size_t j = 0; j < N; ++j) {
+      for (size_t k = 0; k < N; ++k) {
         ASSERT_EQ(X(i,j,k), -Y(i,j,k));
         ASSERT_EQ(std::complex<double>(X(i,j,k)), Z(i,j,k));
         ASSERT_NEAR(X(i,j,k), -W(i,j,k), 1e-6);
@@ -540,4 +540,3 @@ TEST(TensorTest, Negate) {
     }
   }
 }
-


### PR DESCRIPTION
Enable more warnings, and treat warnings as errors when building on TravisCI.
This is related to issue #375 .
