### PR TITLE
Fix is_zero.hpp (re-submitted PR #577)

### DIFF
--- a/utilities/include/alps/numeric/is_zero.hpp
+++ b/utilities/include/alps/numeric/is_zero.hpp
@@ -10,6 +10,8 @@
 #define ALPS_NUMERIC_IS_ZERO_HPP
 
 #include <cmath>
+#include <complex>
+#include <limits>
 #include <type_traits>
 
 namespace alps { namespace numeric {
@@ -19,24 +21,24 @@ namespace detail {
 template<class T, unsigned int N = 5>
 struct precision
 {
-  static inline T epsilon() { return 1e-50; }
+  static inline T epsilon() { return T(1e-50); }
 };
 template<class T> struct precision<T, 0>;
 template<class T> struct precision<T, 1>
 {
-  static inline T epsilon() { return 1e-10; }
+  static inline T epsilon() { return T(1e-10); }
 };
 template<class T> struct precision<T, 2>
 {
-  static inline T epsilon() { return 1e-20; }
+  static inline T epsilon() { return T(1e-20); }
 };
 template<class T> struct precision<T, 3>
 {
-  static inline T epsilon() { return 1e-30; }
+  static inline T epsilon() { return T(1e-30); }
 };
 template<class T> struct precision<T, 4>
 {
-  static inline T epsilon() { return 1e-40; }
+  static inline T epsilon() { return T(1e-40); }
 };
 
 } // end namespace detail
@@ -53,8 +55,9 @@ template<class T> struct precision<T, 4>
 template<unsigned int N, class T>
 inline bool is_zero(T x,
   typename std::enable_if<std::is_arithmetic<T>::value >::type* = 0,
-  typename std::enable_if<std::is_float<T>::value >::type* = 0)
-{ return std::abs(x) < detail::precision<T, N>::epsilon(); }
+  typename std::enable_if<std::is_floating_point<T>::value >::type* = 0)
+{ return (std::abs(x) < detail::precision<T, N>::epsilon() ||
+          std::abs(x) < std::numeric_limits<T>::min()); }
 template<unsigned int N, class T>
 inline bool is_zero(T x,
   typename std::enable_if<std::is_arithmetic<T>::value >::type* = 0,
@@ -85,8 +88,9 @@ inline bool is_zero(const T& x,
 template<class T>
 inline bool is_zero(T x,
   typename std::enable_if<std::is_arithmetic<T>::value >::type* = 0,
-  typename std::enable_if<std::is_float<T>::value >::type* = 0)
-{ return std::abs(x) < detail::precision<T>::epsilon(); }
+  typename std::enable_if<std::is_floating_point<T>::value >::type* = 0)
+{ return (std::abs(x) < detail::precision<T>::epsilon() ||
+          std::abs(x) < std::numeric_limits<T>::min()); }
 template<class T>
 inline bool is_zero(T x,
   typename std::enable_if<std::is_arithmetic<T>::value >::type* = 0,

--- a/utilities/test/CMakeLists.txt
+++ b/utilities/test/CMakeLists.txt
@@ -11,6 +11,7 @@ set (test_src
     vector_functions
     rectangularize
     tensor_test
+    is_zero
     )
 
 set (test_src_mpi

--- a/utilities/test/is_zero.cpp
+++ b/utilities/test/is_zero.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 1998-2018 ALPS Collaboration. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ * For use in publications, see ACKNOWLEDGE.TXT
+ */
+
+#include <gtest/gtest.h>
+#include "alps/numeric/is_zero.hpp"
+
+template <typename T>
+struct FloatingPointZeroTest : public ::testing::Test {
+    typedef T value_type;
+    FloatingPointZeroTest() {}
+    void ZeroTest() {
+      EXPECT_TRUE(alps::numeric::is_zero(value_type(1e-55)));
+      EXPECT_TRUE(alps::numeric::is_zero(value_type(-1e-55)));
+      EXPECT_TRUE(alps::numeric::is_zero<1>(value_type(1e-15)));
+      EXPECT_TRUE(alps::numeric::is_zero<2>(value_type(1e-25)));
+      EXPECT_TRUE(alps::numeric::is_zero<3>(value_type(1e-35)));
+      EXPECT_TRUE(alps::numeric::is_zero<4>(value_type(1e-45)));
+      EXPECT_TRUE(alps::numeric::is_zero<5>(value_type(1e-55)));
+    }
+    void NonZeroTest() {
+      EXPECT_FALSE(alps::numeric::is_zero(std::max(value_type(1e-45), std::numeric_limits<T>::min())));
+      EXPECT_FALSE(alps::numeric::is_zero(-std::max(value_type(1e-45), std::numeric_limits<T>::min())));
+      EXPECT_FALSE(alps::numeric::is_zero<1>(std::max(value_type(1e-5), std::numeric_limits<T>::min())));
+      EXPECT_FALSE(alps::numeric::is_zero<2>(std::max(value_type(1e-15), std::numeric_limits<T>::min())));
+      EXPECT_FALSE(alps::numeric::is_zero<3>(std::max(value_type(1e-25), std::numeric_limits<T>::min())));
+      EXPECT_FALSE(alps::numeric::is_zero<4>(std::max(value_type(1e-35), std::numeric_limits<T>::min())));
+      EXPECT_FALSE(alps::numeric::is_zero<5>(std::max(value_type(1e-45), std::numeric_limits<T>::min())));
+    }
+};
+    
+template <typename T>
+struct IntegralZeroTest : public ::testing::Test {
+    typedef T value_type;
+    IntegralZeroTest() {}
+    void ZeroTest() {
+      EXPECT_TRUE(alps::numeric::is_zero(value_type(0)));
+    }
+    void NonZeroTest() {
+      EXPECT_FALSE(alps::numeric::is_zero(value_type(1)));
+      EXPECT_FALSE(alps::numeric::is_zero(value_type(-1)));
+    }
+};
+    
+typedef ::testing::Types<float, double, long double> float_types;
+TYPED_TEST_CASE(FloatingPointZeroTest, float_types);
+
+TYPED_TEST(FloatingPointZeroTest, ZeroTest) { this->TestFixture::ZeroTest(); }
+TYPED_TEST(FloatingPointZeroTest, NonZeroTest) { this->TestFixture::NonZeroTest(); }
+
+typedef ::testing::Types<bool, char, signed char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long, long long, unsigned long long> integral_types;
+TYPED_TEST_CASE(IntegralZeroTest, integral_types);
+
+TYPED_TEST(IntegralZeroTest, ZeroTest) { this->TestFixture::ZeroTest(); }
+TYPED_TEST(IntegralZeroTest, NonZeroTest) { this->TestFixture::NonZeroTest(); }


### PR DESCRIPTION
This is PR #577 from @wistaria, but based on master rather than devel branch

From the original PR:
> No is_float in C++11
Fixed is_zero for float
Add unit test
