### PR TITLE
[alea] Change sizes to `size_t`, counts to `uint64_t`.

### DIFF
--- a/alea/include/alps/alea/autocorr.hpp
+++ b/alea/include/alps/alea/autocorr.hpp
@@ -71,7 +71,7 @@ public:
     using level_acc_type = var_acc<T, circular_var>;
 
 public:
-    autocorr_acc(size_t size=1, size_t batch_size=1, size_t granularity=2);
+    autocorr_acc(size_t size=1, uint64_t batch_size=1, size_t granularity=2);
 
     /** Re-allocate and thus clear all accumulated data */
     void reset();
@@ -80,7 +80,7 @@ public:
     void set_size(size_t size);
 
     /** Update the batch size and discard all measurements */
-    void set_batch_size(size_t batch_size);
+    void set_batch_size(uint64_t batch_size);
 
     /** Update the increment between levels and discard all measurements*/
     void set_granularity(size_t granularity);
@@ -98,7 +98,7 @@ public:
     autocorr_acc &operator<<(const autocorr_result<T> &result);
 
     /** Returns sample size, i.e., number of accumulated data points */
-    size_t count() const { return count_; }
+    uint64_t count() const { return count_; }
 
     /** Returns result corresponding to current state of accumulator */
     autocorr_result<T> result() const;
@@ -111,7 +111,7 @@ public:
     const level_acc_type &level(size_t i) const { return level_[i]; }
 
 protected:
-    void add(const computed<T> &source, size_t count);
+    void add(const computed<T> &source, uint64_t count);
 
     void add_level();
 
@@ -161,7 +161,7 @@ public:
     size_t size() const { return level_[0].size(); }
 
     /** Returns sample size, i.e., number of accumulated data points */
-    size_t count() const { return level_[0].count(); }
+    uint64_t count() const { return level_[0].count(); }
 
     /** Returns sum of squared samples sizes */
     double count2() const;
@@ -196,9 +196,9 @@ public:
     /** Write some info about the result to a stream */
     friend std::ostream &operator<< <>(std::ostream &, const autocorr_result &);
 
-    size_t find_level(size_t min_samples) const;
+    size_t find_level(uint64_t min_samples) const;
 
-    size_t batch_size(size_t level) const;
+    uint64_t batch_size(size_t level) const;
 
     size_t nlevel() const { return level_.size(); }
 

--- a/alea/include/alps/alea/batch.hpp
+++ b/alea/include/alps/alea/batch.hpp
@@ -98,7 +98,7 @@ public:
     void set_size(size_t size);
 
     /** Update the number of batches and discard all measurements, if any */
-    void set_num_batches(uint64_t batch_size);
+    void set_num_batches(size_t num_batches);
 
     /** Update the batch size and discard all measurements, if any */
     void set_batch_size(uint64_t batch_size);

--- a/alea/include/alps/alea/batch.hpp
+++ b/alea/include/alps/alea/batch.hpp
@@ -56,14 +56,14 @@ public:
     const typename eigen<T>::matrix &batch() const { return batch_; }
 
     /** Returns sample size (number of accumulated points) for each batch */
-    typename eigen<size_t>::row &count() { return count_; }
+    typename eigen<uint64_t>::row &count() { return count_; }
 
     /** Returns sample size (number of accumulated points) for each batch */
-    const typename eigen<size_t>::row &count() const { return count_; }
+    const typename eigen<uint64_t>::row &count() const { return count_; }
 
 private:
     typename eigen<T>::matrix batch_;
-    typename eigen<size_t>::row count_;
+    typename eigen<uint64_t>::row count_;
 };
 
 template <typename T>
@@ -85,7 +85,7 @@ public:
     using value_type = T;
 
 public:
-    batch_acc(size_t size=1, size_t num_batches=256, size_t base_size=1);
+    batch_acc(size_t size=1, size_t num_batches=256, uint64_t base_size=1);
 
     batch_acc(const batch_acc &other);
 
@@ -98,10 +98,10 @@ public:
     void set_size(size_t size);
 
     /** Update the number of batches and discard all measurements, if any */
-    void set_num_batches(size_t batch_size);
+    void set_num_batches(uint64_t batch_size);
 
     /** Update the batch size and discard all measurements, if any */
-    void set_batch_size(size_t batch_size);
+    void set_batch_size(uint64_t batch_size);
 
     /** Returns `false` if `finalize()` has been called, `true` otherwise */
     bool valid() const { return (bool)store_; }
@@ -119,7 +119,7 @@ public:
     batch_acc &operator<<(const batch_result<T> &result);
 
     /** Returns sample size, i.e., total number of accumulated data points */
-    size_t count() const { return store_->count().sum(); }
+    uint64_t count() const { return store_->count().sum(); }
 
     /** Returns result corresponding to current state of accumulator */
     batch_result<T> result() const;
@@ -132,12 +132,12 @@ public:
 
     const internal::galois_hopper &cursor() const { return cursor_; }
 
-    const typename eigen<size_t>::row &offset() const { return offset_; }
+    const typename eigen<uint64_t>::row &offset() const { return offset_; }
 
     size_t current_batch_size() const { return base_size_ * cursor_.factor(); }
 
 protected:
-    void add(const computed<T> &source, size_t count);
+    void add(const computed<T> &source, uint64_t count);
 
     void next_batch();
 
@@ -147,7 +147,7 @@ private:
     size_t size_, num_batches_, base_size_;
     std::unique_ptr< batch_data<value_type> > store_;
     internal::galois_hopper cursor_;
-    typename eigen<size_t>::row offset_;
+    typename eigen<uint64_t>::row offset_;
 };
 
 template <typename T>
@@ -194,7 +194,7 @@ public:
     size_t num_batches() const { return store_->num_batches(); }
 
     /** Returns sample size, i.e., total number of accumulated data points */
-    size_t count() const { return store_->count().sum(); }
+    uint64_t count() const { return store_->count().sum(); }
 
     /** Returns sum of squared sample sizes */
     double count2() const { return store_->count().squaredNorm(); }

--- a/alea/include/alps/alea/bundle.hpp
+++ b/alea/include/alps/alea/bundle.hpp
@@ -20,7 +20,7 @@ template <typename T>
 class bundle
 {
 public:
-    bundle(size_t size, size_t target) : sum_(size), target_(target) { reset(); }
+    bundle(size_t size, uint64_t target) : sum_(size), target_(target) { reset(); }
 
     /** Re-allocate and thus clear all accumulated data */
     void reset() { sum_.fill(0); count_ = 0; }
@@ -30,13 +30,13 @@ public:
     /** Number of components of the random vector (e.g., size of mean) */
     size_t size() const { return sum_.rows(); }
 
-    size_t &target() { return target_; }
+    uint64_t &target() { return target_; }
 
-    const size_t &target() const { return target_; }
+    const uint64_t &target() const { return target_; }
 
-    size_t &count() { return count_; }
+    uint64_t &count() { return count_; }
 
-    size_t count() const { return count_; }
+    uint64_t count() const { return count_; }
 
     column<T> &sum() { return sum_; }
 
@@ -44,7 +44,7 @@ public:
 
 private:
     column<T> sum_;
-    size_t target_, count_;
+    uint64_t target_, count_;
 };
 
 }}

--- a/alea/include/alps/alea/core.hpp
+++ b/alea/include/alps/alea/core.hpp
@@ -238,7 +238,7 @@ struct reducer_setup
     size_t pos;
 
     /** Total number of instances (thread count/MPI size/etc.) */
-    size_t count;
+    uint64_t count;
 
     /** Reductions will yield valid result on this instance */
     bool have_result;

--- a/alea/include/alps/alea/core.hpp
+++ b/alea/include/alps/alea/core.hpp
@@ -272,13 +272,16 @@ struct reducer
     virtual reducer_setup get_setup() const = 0;
 
     /** Get maximum of scalar value over all instances (immediate) */
-    virtual long get_max(long value) const = 0;
+    virtual int64_t get_max(int64_t value) const = 0;
 
     /** Reduce double data-set into `data` */
     virtual void reduce(view<double> data) const = 0;
 
+    /** Reduce int data-set into `data` */
+    virtual void reduce(view<int32_t> data) const = 0;
+
     /** Reduce long data-set into `data` */
-    virtual void reduce(view<long> data) const = 0;
+    virtual void reduce(view<int64_t> data) const = 0;
 
     /** Finish reduction of all data if deferred */
     virtual void commit() const = 0;
@@ -297,8 +300,11 @@ struct reducer
     void reduce(view<complex_op<double> > data) const {
         reduce(view<double>((double *)data.data(), 4 * data.size()));
     }
-    void reduce(view<unsigned long> data) const {
-        reduce(view<long>((long *)data.data(), data.size()));
+    void reduce(view<uint32_t> data) const {
+        reduce(view<int32_t>((int32_t *)data.data(), data.size()));
+    }
+    void reduce(view<uint64_t> data) const {
+        reduce(view<int64_t>((int64_t *)data.data(), data.size()));
     }
 };
 

--- a/alea/include/alps/alea/core.hpp
+++ b/alea/include/alps/alea/core.hpp
@@ -21,6 +21,10 @@ namespace alps { namespace alea {
 
 using std::size_t;
 using std::ptrdiff_t;
+using std::uint64_t;
+using std::int64_t;
+using std::uint32_t;
+using std::int32_t;
 
 /** Estimator cannot add to view as the sizes are mismatched */
 struct size_mismatch : public std::exception { };
@@ -325,10 +329,16 @@ struct serializer
     virtual void write(const std::string &key, ndview<const complex_op<double>>) = 0;
 
     /** Writes a named multi-dimensional array of longs */
-    virtual void write(const std::string &key, ndview<const long>) = 0;
+    virtual void write(const std::string &key, ndview<const int64_t>) = 0;
 
     /** Writes a named multi-dimensional array of unsigned longs */
-    virtual void write(const std::string &key, ndview<const unsigned long>) = 0;
+    virtual void write(const std::string &key, ndview<const uint64_t>) = 0;
+
+    /** Writes a named multi-dimensional array of int */
+    virtual void write(const std::string &key, ndview<const int32_t>) = 0;
+
+    /** Writes a named multi-dimensional array of unsigned int */
+    virtual void write(const std::string &key, ndview<const uint32_t>) = 0;
 
     /** Returns a copy of `*this` created using `new` */
     virtual serializer *clone() { throw unsupported_operation(); }
@@ -369,11 +379,17 @@ struct deserializer
     /** Reads a named multi-dimensional array of double complex operand */
     virtual void read(const std::string &key, ndview<complex_op<double>>) = 0;
 
-    /** Reads a named multi-dimensional array of long */
-    virtual void read(const std::string &key, ndview<long>) = 0;
+    /** Reads a named multi-dimensional array of longs */
+    virtual void read(const std::string &key, ndview<int64_t>) = 0;
 
-    /** Reads a named multi-dimensional array of unsigned long */
-    virtual void read(const std::string &key, ndview<unsigned long>) = 0;
+    /** Reads a named multi-dimensional array of unsigned longs */
+    virtual void read(const std::string &key, ndview<uint64_t>) = 0;
+
+    /** Reads a named multi-dimensional array of int */
+    virtual void read(const std::string &key, ndview<int32_t>) = 0;
+
+    /** Reads a named multi-dimensional array of unsigned int */
+    virtual void read(const std::string &key, ndview<uint32_t>) = 0;
 
     /** Returns a copy of `*this` created using `new` */
     virtual deserializer *clone() { throw unsupported_operation(); }

--- a/alea/include/alps/alea/covariance.hpp
+++ b/alea/include/alps/alea/covariance.hpp
@@ -63,10 +63,10 @@ public:
     size_t size() const { return data_.rows(); }
 
     /** Returns sample size, i.e., number of accumulated data points */
-    size_t count() const { return count_; }
+    uint64_t count() const { return count_; }
 
     /** Returns sample size, i.e., number of accumulated data points */
-    size_t &count() { return count_; }
+    uint64_t &count() { return count_; }
 
     /** Returns sum of squared weights */
     double count2() const { return count2_; }
@@ -89,7 +89,7 @@ public:
 private:
     column<T> data_;
     cov_matrix_type data2_;
-    size_t count_;
+    uint64_t count_;
     double count2_;
 
     friend class cov_acc<T, Strategy>;
@@ -125,7 +125,7 @@ public:
     using cov_matrix_type = typename eigen<cov_type>::matrix;
 
 public:
-    cov_acc(size_t size=1, size_t batch_size=1);
+    cov_acc(size_t size=1, uint64_t batch_size=1);
 
     cov_acc(const cov_acc &other);
 
@@ -138,7 +138,7 @@ public:
     void set_size(size_t size);
 
     /** Update the batch size and discard current batch */
-    void set_batch_size(size_t batch_size);
+    void set_batch_size(uint64_t batch_size);
 
     /** Returns `false` if `finalize()` has been called, `true` otherwise */
     bool valid() const { return (bool)store_; }
@@ -147,7 +147,7 @@ public:
     size_t size() const { return current_.size(); }
 
     /** Returns number of data points per batch */
-    size_t batch_size() const { return current_.target(); }
+    uint64_t batch_size() const { return current_.target(); }
 
     /** Add computed vector to the accumulator */
     cov_acc& operator<<(const computed<T>& src){ add(src, 1); return *this; }
@@ -156,7 +156,7 @@ public:
     cov_acc &operator<<(const cov_result<T,Strategy> &result);
 
     /** Returns sample size, i.e., number of accumulated data points */
-    size_t count() const { return store_->count(); }
+    uint64_t count() const { return store_->count(); }
 
     /** Returns result corresponding to current state of accumulator */
     cov_result<T,Strategy> result() const;
@@ -170,7 +170,7 @@ public:
     const cov_data<T,Strategy> &store() const { return *store_; }
 
 protected:
-    void add(const computed<T> &source, size_t count);
+    void add(const computed<T> &source, uint64_t count);
 
     void add_bundle();
 
@@ -240,7 +240,7 @@ public:
     size_t size() const { return store_->size(); }
 
     /** Returns sample size, i.e., number of accumulated data points */
-    size_t count() const { return store_->count(); }
+    uint64_t count() const { return store_->count(); }
 
     /** Returns sum of squared sample sizes */
     double count2() const { return store_->count2(); }

--- a/alea/include/alps/alea/hdf5.hpp
+++ b/alea/include/alps/alea/hdf5.hpp
@@ -53,11 +53,19 @@ public:
         throw unsupported_operation();  // FIXME
     }
 
-    void write(const std::string &key, ndview<const long> value) override {
+    void write(const std::string &key, ndview<const int64_t> value) override {
         do_write(key, value);
     }
 
-    void write(const std::string &key, ndview<const unsigned long> value) override {
+    void write(const std::string &key, ndview<const uint64_t> value) override {
+        do_write(key, value);
+    }
+
+    void write(const std::string &key, ndview<const int32_t> value) override {
+        do_write(key, value);
+    }
+
+    void write(const std::string &key, ndview<const uint32_t> value) override {
         do_write(key, value);
     }
 
@@ -79,11 +87,19 @@ public:
         throw unsupported_operation();  // FIXME
     }
 
-    void read(const std::string &key, ndview<long> value) override {
+    void read(const std::string &key, ndview<int64_t> value) override {
         do_read(key, value);
     }
 
-    void read(const std::string &key, ndview<unsigned long> value) override {
+    void read(const std::string &key, ndview<uint64_t> value) override {
+        do_read(key, value);
+    }
+
+    void read(const std::string &key, ndview<int32_t> value) override {
+        do_read(key, value);
+    }
+
+    void read(const std::string &key, ndview<uint32_t> value) override {
         do_read(key, value);
     }
 

--- a/alea/include/alps/alea/internal/galois.hpp
+++ b/alea/include/alps/alea/internal/galois.hpp
@@ -72,8 +72,11 @@ private:
     void advance_galois();
 
     size_t size_;
-    size_t level_, factor_;
-    size_t current_, skip_, level_pos_, cycle_;
+    size_t level_, level_pos_, cycle_;
+
+    // Internally, these need to be 64-bit numbers, because skip and factor
+    // will reflect the number of "merges".
+    uint64_t current_, skip_, factor_;
 };
 
 }}}

--- a/alea/include/alps/alea/mean.hpp
+++ b/alea/include/alps/alea/mean.hpp
@@ -54,10 +54,10 @@ public:
     size_t size() const { return data_.rows(); }
 
     /** Returns number of accumulated data points */
-    size_t count() const { return count_; }
+    uint64_t count() const { return count_; }
 
     /** Returns number of accumulated data points */
-    size_t &count() { return count_; }
+    uint64_t &count() { return count_; }
 
     /** Returns data vector (either mean or sum) */
     const column<T> &data() const { return data_; }
@@ -73,7 +73,7 @@ public:
 
 private:
     column<T> data_;
-    size_t count_;
+    uint64_t count_;
 
     friend class mean_acc<T>;
     friend class mean_result<T>;
@@ -126,7 +126,7 @@ public:
     mean_acc &operator<<(const mean_result<T> &result);
 
     /** Returns sample size, i.e., number of accumulated data points */
-    size_t count() const { return store_->count(); }
+    uint64_t count() const { return store_->count(); }
 
     /** Returns result corresponding to current state of accumulator */
     mean_result<T> result() const;
@@ -138,7 +138,7 @@ public:
     const mean_data<T> &store() const { return *store_; }
 
 protected:
-    void add(const computed<T> &source, size_t count);
+    void add(const computed<T> &source, uint64_t count);
 
     void finalize_to(mean_result<T> &result);
 
@@ -182,7 +182,7 @@ public:
     size_t size() const { return store_->size(); }
 
     /** Returns sample size, i.e., number of accumulated data points */
-    size_t count() const { return store_->count(); }
+    uint64_t count() const { return store_->count(); }
 
     /** Returns sample mean */
     const column<T> &mean() const { return store_->data(); }

--- a/alea/include/alps/alea/mpi.hpp
+++ b/alea/include/alps/alea/mpi.hpp
@@ -55,7 +55,7 @@ struct mpi_reducer
         return mpi_setup;
     }
 
-    long get_max(long data) const override
+    int64_t get_max(int64_t data) const override
     {
         mpi::checked(MPI_Allreduce(MPI_IN_PLACE, &data, 1, MPI_LONG,
                                    MPI_MAX, comm_));
@@ -64,7 +64,9 @@ struct mpi_reducer
 
     void reduce(view<double> data) const override { inplace_reduce(data); }
 
-    void reduce(view<long> data) const override { inplace_reduce(data); }
+    void reduce(view<int32_t> data) const override { inplace_reduce(data); }
+
+    void reduce(view<int64_t> data) const override { inplace_reduce(data); }
 
     void commit() const override { }
 

--- a/alea/include/alps/alea/plugin/stream_serializer.hpp
+++ b/alea/include/alps/alea/plugin/stream_serializer.hpp
@@ -53,11 +53,19 @@ public:
     {
         do_write(data_view);
     }
-    void write(const std::string &, ndview<const long> data_view) override
+    void write(const std::string &, ndview<const int64_t> data_view) override
     {
         do_write(data_view);
     }
-    void write(const std::string &, ndview<const unsigned long> data_view) override
+    void write(const std::string &, ndview<const uint64_t> data_view) override
+    {
+        do_write(data_view);
+    }
+    void write(const std::string &, ndview<const int32_t> data_view) override
+    {
+        do_write(data_view);
+    }
+    void write(const std::string &, ndview<const uint32_t> data_view) override
     {
         do_write(data_view);
     }
@@ -119,11 +127,19 @@ public:
     {
         do_read(value);
     }
-    void read(const std::string &, ndview<long> value) override
+    void read(const std::string &, ndview<int64_t> value) override
     {
         do_read(value);
     }
-    void read(const std::string &, ndview<unsigned long> value) override
+    void read(const std::string &, ndview<uint64_t> value) override
+    {
+        do_read(value);
+    }
+    void read(const std::string &, ndview<int32_t> value) override
+    {
+        do_read(value);
+    }
+    void read(const std::string &, ndview<uint32_t> value) override
     {
         do_read(value);
     }

--- a/alea/include/alps/alea/result.hpp
+++ b/alea/include/alps/alea/result.hpp
@@ -54,7 +54,7 @@ public:
     size_t size() const;
 
     /** Returns number of accumulated data points */
-    size_t count() const;
+    uint64_t count() const;
 
     /** Returns sample mean */
     template <typename T>

--- a/alea/include/alps/alea/serialize.hpp
+++ b/alea/include/alps/alea/serialize.hpp
@@ -88,10 +88,16 @@ namespace alps { namespace alea {
 
 // Serialization methods
 
-inline void serialize(serializer &ser, const std::string &key, unsigned long value) {
+inline void serialize(serializer &ser, const std::string &key, uint32_t value) {
     internal::scalar_serialize(ser, key, value);
 }
-inline void serialize(serializer &ser, const std::string &key, long value) {
+inline void serialize(serializer &ser, const std::string &key, int32_t value) {
+    internal::scalar_serialize(ser, key, value);
+}
+inline void serialize(serializer &ser, const std::string &key, uint64_t value) {
+    internal::scalar_serialize(ser, key, value);
+}
+inline void serialize(serializer &ser, const std::string &key, int64_t value) {
     internal::scalar_serialize(ser, key, value);
 }
 inline void serialize(serializer &ser, const std::string &key, double value) {
@@ -137,10 +143,16 @@ void serialize(serializer &ser, const std::string &key,
 
 // Argument-oriented deserialization
 
-inline void deserialize(deserializer &ser, const std::string &key, unsigned long &value) {
+inline void deserialize(deserializer &ser, const std::string &key, uint64_t &value) {
     internal::scalar_deserialize(ser, key, value);
 }
-inline void deserialize(deserializer &ser, const std::string &key, long &value) {
+inline void deserialize(deserializer &ser, const std::string &key, int64_t &value) {
+    internal::scalar_deserialize(ser, key, value);
+}
+inline void deserialize(deserializer &ser, const std::string &key, uint32_t &value) {
+    internal::scalar_deserialize(ser, key, value);
+}
+inline void deserialize(deserializer &ser, const std::string &key, int32_t &value) {
     internal::scalar_deserialize(ser, key, value);
 }
 inline void deserialize(deserializer &ser, const std::string &key, double &value) {

--- a/alea/include/alps/alea/util/serializer.hpp
+++ b/alea/include/alps/alea/util/serializer.hpp
@@ -26,9 +26,13 @@ public:
 
     void write(const std::string &, ndview<const complex_op<double>>) override { }
 
-    void write(const std::string &, ndview<const long>) override { }
+    void write(const std::string &, ndview<const int64_t>) override { }
 
-    void write(const std::string &, ndview<const unsigned long>) override { }
+    void write(const std::string &, ndview<const uint64_t>) override { }
+
+    void write(const std::string &, ndview<const int32_t>) override { }
+
+    void write(const std::string &, ndview<const uint32_t>) override { }
 
     null_serializer *clone() override { return new null_serializer(*this); }
 
@@ -76,11 +80,19 @@ public:
         do_write(key, value);
     }
 
-    void write(const std::string &key, ndview<const long> value) override {
+    void write(const std::string &key, ndview<const int64_t> value) override {
         do_write(key, value);
     }
 
-    void write(const std::string &key, ndview<const unsigned long> value) override {
+    void write(const std::string &key, ndview<const uint64_t> value) override {
+        do_write(key, value);
+    }
+
+    void write(const std::string &key, ndview<const int32_t> value) override {
+        do_write(key, value);
+    }
+
+    void write(const std::string &key, ndview<const uint32_t> value) override {
         do_write(key, value);
     }
 

--- a/alea/include/alps/alea/variance.hpp
+++ b/alea/include/alps/alea/variance.hpp
@@ -65,7 +65,7 @@ public:
     size_t size() const { return data_.rows(); }
 
     /** Returns sample size, i.e., number of accumulated data points */
-    size_t count() const { return count_; }
+    uint64_t count() const { return count_; }
 
     /** Returns sample size, i.e., number of accumulated data points */
     size_t &count() { return count_; }
@@ -91,7 +91,7 @@ public:
 private:
     column<T> data_;
     column<var_type> data2_;
-    size_t count_;
+    uint64_t count_;
     double count2_;
 
     friend class var_acc<T, Strategy>;
@@ -135,7 +135,7 @@ public:
     using var_type = typename bind<Strategy, T>::var_type;
 
 public:
-    var_acc(size_t size=1, size_t batch_size=1);
+    var_acc(size_t size=1, uint64_t batch_size=1);
 
     var_acc(const var_acc &other);
 
@@ -148,7 +148,7 @@ public:
     void set_size(size_t size);
 
     /** Update the batch size and discard current batch */
-    void set_batch_size(size_t batch_size);
+    void set_batch_size(uint64_t batch_size);
 
     /** Returns `false` if `finalize()` has been called, `true` otherwise */
     bool valid() const { return (bool)store_; }
@@ -157,7 +157,7 @@ public:
     size_t size() const { return current_.size(); }
 
     /** Returns number of data points per batch */
-    size_t batch_size() const { return current_.target(); }
+    uint64_t batch_size() const { return current_.target(); }
 
     /** Add computed vector to the accumulator */
     var_acc &operator<<(const computed<T> &src) { add(src, 1, nullptr); return *this; }
@@ -166,7 +166,7 @@ public:
     var_acc &operator<<(const var_result<T,Strategy> &result);
 
     /** Returns sample size, i.e., number of accumulated data points */
-    size_t count() const { return store_->count(); }
+    uint64_t count() const { return store_->count(); }
 
     /** Returns result corresponding to current state of accumulator */
     var_result<T,Strategy> result() const;
@@ -180,7 +180,7 @@ public:
     const var_data<T,Strategy> &store() const { return *store_; }
 
 protected:
-    void add(const computed<T> &source, size_t count, var_acc *cascade);
+    void add(const computed<T> &source, uint64_t count, var_acc *cascade);
 
     void add_bundle(var_acc *cascade);
 
@@ -239,7 +239,7 @@ public:
     double batch_size() const { return store_->count2() / store_->count(); }
 
     /** Returns sample size, i.e., number of accumulated data points */
-    size_t count() const { return store_->count(); }
+    uint64_t count() const { return store_->count(); }
 
     /** Returns sum of squared sample sizes */
     double count2() const { return store_->count2(); }

--- a/alea/include/alps/alea/variance.hpp
+++ b/alea/include/alps/alea/variance.hpp
@@ -68,7 +68,7 @@ public:
     uint64_t count() const { return count_; }
 
     /** Returns sample size, i.e., number of accumulated data points */
-    size_t &count() { return count_; }
+    uint64_t &count() { return count_; }
 
     /** Returns sum of squared weights */
     double count2() const { return count2_; }

--- a/alea/src/autocorr.cpp
+++ b/alea/src/autocorr.cpp
@@ -149,7 +149,7 @@ template bool operator==(const autocorr_result<std::complex<double>> &r1,
                          const autocorr_result<std::complex<double>> &r2);
 
 template <typename T>
-size_t autocorr_result<T>::batch_size(size_t i) const
+uint64_t autocorr_result<T>::batch_size(size_t i) const
 {
     return level_[i].batch_size();
 }
@@ -251,8 +251,10 @@ void serialize(serializer &s, const std::string &key, const autocorr_result<T> &
 {
     internal::check_valid(self);
     internal::serializer_sentry group(s, key);
-    serialize(s, "@size", self.size());
-    serialize(s, "@nlevel", self.nlevel());
+
+    // Write size and nlevel as 64-bit integers for consistency
+    serialize(s, "@size", static_cast<uint64_t>(self.size()));
+    serialize(s, "@nlevel", static_cast<uint64_t>(self.nlevel()));
 
     s.enter("level");
     for (size_t i = 0; i != self.nlevel(); ++i)
@@ -271,10 +273,11 @@ void deserialize(deserializer &s, const std::string &key, autocorr_result<T> &se
     typedef typename autocorr_result<T>::var_type var_type;
     internal::deserializer_sentry group(s, key);
 
+    size_t scalar_size = 1;
+    s.read("@size", ndview<uint64_t>(nullptr, &scalar_size, 0)); // discard
+
     // first deserialize the fundamentals and make sure that the target fits
-    size_t new_size = 1;
-    s.read("@size", ndview<size_t>(nullptr, &new_size, 0)); // discard
-    size_t new_nlevel;
+    uint64_t new_nlevel;
     deserialize(s, "@nlevel", new_nlevel);
     self.level_.resize(new_nlevel);
 
@@ -283,10 +286,10 @@ void deserialize(deserializer &s, const std::string &key, autocorr_result<T> &se
         deserialize(s, std::to_string(i), self.level_[i]);
     s.exit();
 
+    scalar_size = self.size();
     s.enter("mean");
-    new_size = self.size();
-    s.read("value", ndview<T>(nullptr, &new_size, 1)); // discard
-    s.read("error", ndview<var_type>(nullptr, &new_size, 1)); // discard
+    s.read("value", ndview<T>(nullptr, &scalar_size, 1)); // discard
+    s.read("error", ndview<var_type>(nullptr, &scalar_size, 1)); // discard
     s.exit();
 }
 

--- a/alea/src/autocorr.cpp
+++ b/alea/src/autocorr.cpp
@@ -12,7 +12,7 @@
 namespace alps { namespace alea {
 
 template <typename T>
-autocorr_acc<T>::autocorr_acc(size_t size, size_t batch_size, size_t granularity)
+autocorr_acc<T>::autocorr_acc(size_t size, uint64_t batch_size, size_t granularity)
     : size_(size)
     , batch_size_(batch_size)
     , count_(0)
@@ -40,7 +40,7 @@ void autocorr_acc<T>::set_size(size_t size)
 }
 
 template <typename T>
-void autocorr_acc<T>::set_batch_size(size_t batch_size)
+void autocorr_acc<T>::set_batch_size(uint64_t batch_size)
 {
     // TODO: handle the case where we just discard levels more gracefully
     batch_size_ = batch_size;
@@ -64,7 +64,7 @@ void autocorr_acc<T>::add_level()
 }
 
 template <typename T>
-void autocorr_acc<T>::add(const computed<T> &source, size_t count)
+void autocorr_acc<T>::add(const computed<T> &source, uint64_t count)
 {
     assert(count_ < nextlevel_);
     internal::check_valid(*this);
@@ -155,7 +155,7 @@ size_t autocorr_result<T>::batch_size(size_t i) const
 }
 
 template <typename T>
-size_t autocorr_result<T>::find_level(size_t min_samples) const
+size_t autocorr_result<T>::find_level(uint64_t min_samples) const
 {
     // TODO: this can be done in O(1)
     for (unsigned i = nlevel(); i != 0; --i) {

--- a/alea/src/batch.cpp
+++ b/alea/src/batch.cpp
@@ -266,7 +266,7 @@ void batch_result<T>::reduce(const reducer &r, bool pre_commit, bool post_commit
     internal::check_valid(*this);
     if (pre_commit) {
         r.reduce(view<T>(store_->batch().data(), store_->batch().size()));
-        r.reduce(view<size_t>(store_->count().data(), store_->num_batches()));
+        r.reduce(view<uint64_t>(store_->count().data(), store_->num_batches()));
     }
     if (pre_commit && post_commit) {
         r.commit();

--- a/alea/src/batch.cpp
+++ b/alea/src/batch.cpp
@@ -35,7 +35,7 @@ template class batch_data<std::complex<double> >;
 
 
 template <typename T>
-batch_acc<T>::batch_acc(size_t size, size_t num_batches, size_t base_size)
+batch_acc<T>::batch_acc(size_t size, size_t num_batches, uint64_t base_size)
     : size_(size)
     , num_batches_(num_batches)
     , base_size_(base_size)
@@ -97,7 +97,7 @@ void batch_acc<T>::set_size(size_t size)
 }
 
 template <typename T>
-void batch_acc<T>::set_batch_size(size_t batch_size)
+void batch_acc<T>::set_batch_size(uint64_t batch_size)
 {
     base_size_ = batch_size;
     if (valid())
@@ -116,7 +116,7 @@ void batch_acc<T>::set_num_batches(size_t num_batches)
 }
 
 template <typename T>
-void batch_acc<T>::add(const computed<T> &source, size_t count)
+void batch_acc<T>::add(const computed<T> &source, uint64_t count)
 {
     internal::check_valid(*this);
 

--- a/alea/src/covariance.cpp
+++ b/alea/src/covariance.cpp
@@ -72,7 +72,7 @@ template class cov_data<std::complex<double>, elliptic_var>;
 
 
 template <typename T, typename Str>
-cov_acc<T,Str>::cov_acc(size_t size, size_t batch_size)
+cov_acc<T,Str>::cov_acc(size_t size, uint64_t batch_size)
     : store_(new cov_data<T,Str>(size))
     , current_(size, batch_size)
 { }
@@ -111,7 +111,7 @@ void cov_acc<T,Str>::set_size(size_t size)
 }
 
 template <typename T, typename Str>
-void cov_acc<T,Str>::set_batch_size(size_t batch_size)
+void cov_acc<T,Str>::set_batch_size(uint64_t batch_size)
 {
     // TODO: allow resizing with reset
     current_.target() = batch_size;
@@ -119,7 +119,7 @@ void cov_acc<T,Str>::set_batch_size(size_t batch_size)
 }
 
 template <typename T, typename Str>
-void cov_acc<T,Str>::add(const computed<value_type> &source, size_t count)
+void cov_acc<T,Str>::add(const computed<value_type> &source, uint64_t count)
 {
     internal::check_valid(*this);
     source.add_to(view<T>(current_.sum().data(), current_.size()));

--- a/alea/src/mean.cpp
+++ b/alea/src/mean.cpp
@@ -58,7 +58,7 @@ mean_acc<T> &mean_acc<T>::operator=(const mean_acc &other)
 }
 
 template <typename T>
-void mean_acc<T>::add(const computed<T> &source, size_t count)
+void mean_acc<T>::add(const computed<T> &source, uint64_t count)
 {
     internal::check_valid(*this);
     source.add_to(view<T>(store_->data().data(), size()));

--- a/alea/src/mean.cpp
+++ b/alea/src/mean.cpp
@@ -163,7 +163,7 @@ void mean_result<T>::reduce(const reducer &r, bool pre_commit, bool post_commit)
     if (pre_commit) {
         store_->convert_to_sum();
         r.reduce(view<T>(store_->data().data(), store_->data().rows()));
-        r.reduce(view<size_t>(&store_->count(), 1));
+        r.reduce(view<uint64_t>(&store_->count(), 1));
     }
     if (pre_commit && post_commit) {
         r.commit();
@@ -187,7 +187,8 @@ void serialize(serializer &s, const std::string &key, const mean_result<T> &self
     internal::check_valid(self);
     internal::serializer_sentry group(s, key);
 
-    serialize(s, "@size", self.store_->data_.size());
+    // serialize to uint64_t to make sure we are consistent across 32/64 bit
+    serialize(s, "@size", static_cast<uint64_t>(self.store_->data_.size()));
     serialize(s, "count", self.store_->count_);
     s.enter("mean");
     serialize(s, "value", self.store_->data_);
@@ -199,9 +200,12 @@ void deserialize(deserializer &s, const std::string &key, mean_result<T> &self)
 {
     internal::deserializer_sentry group(s, key);
 
+    // deserialize from uint64_t
+    uint64_t new_size_des;
+    deserialize(s, "@size", new_size_des);
+
     // first deserialize the fundamentals and make sure that the target fits
-    size_t new_size;
-    deserialize(s, "@size", new_size);
+    size_t new_size = new_size_des;
     if (!self.valid() || self.size() != new_size)
         self.store_.reset(new mean_data<T>(new_size));
 

--- a/alea/src/result.cpp
+++ b/alea/src/result.cpp
@@ -29,10 +29,10 @@ struct size_visitor
 
 struct count_visitor
 {
-    typedef size_t result_type;
+    typedef uint64_t result_type;
 
     template <typename Res>
-    size_t operator() (const Res &r) const { return r.count(); }
+    uint64_t operator() (const Res &r) const { return r.count(); }
 };
 
 template <typename T>          // T = double or std::complex<double>
@@ -131,7 +131,7 @@ size_t result::size() const
     return boost::apply_visitor(size_visitor(), res_);
 }
 
-size_t result::count() const
+uint64_t result::count() const
 {
     return boost::apply_visitor(count_visitor(), res_);
 }

--- a/alea/src/variance.cpp
+++ b/alea/src/variance.cpp
@@ -74,7 +74,7 @@ template class var_data<std::complex<double>, elliptic_var>;
 
 
 template <typename T, typename Str>
-var_acc<T,Str>::var_acc(size_t size, size_t batch_size)
+var_acc<T,Str>::var_acc(size_t size, uint64_t batch_size)
     : store_(new var_data<T,Str>(size))
     , current_(size, batch_size)
 { }
@@ -113,7 +113,7 @@ void var_acc<T,Str>::set_size(size_t size)
 }
 
 template <typename T, typename Str>
-void var_acc<T,Str>::set_batch_size(size_t batch_size)
+void var_acc<T,Str>::set_batch_size(uint64_t batch_size)
 {
     // TODO: allow resizing with reset
     current_.target() = batch_size;
@@ -121,7 +121,7 @@ void var_acc<T,Str>::set_batch_size(size_t batch_size)
 }
 
 template <typename T, typename Str>
-void var_acc<T,Str>::add(const computed<T> &source, size_t count,
+void var_acc<T,Str>::add(const computed<T> &source, uint64_t count,
                          var_acc<T,Str> *cascade)
 {
     internal::check_valid(*this);

--- a/alea/src/variance.cpp
+++ b/alea/src/variance.cpp
@@ -254,7 +254,7 @@ void var_result<T,Str>::reduce(const reducer &r, bool pre_commit, bool post_comm
         store_->convert_to_sum();
         r.reduce(view<T>(store_->data().data(), store_->data().rows()));
         r.reduce(view<var_type>(store_->data2().data(), store_->data2().rows()));
-        r.reduce(view<size_t>(&store_->count(), 1));
+        r.reduce(view<uint64_t>(&store_->count(), 1));
         r.reduce(view<double>(&store_->count2(), 1));
     }
     if (pre_commit && post_commit) {
@@ -280,7 +280,8 @@ void serialize(serializer &s, const std::string &key, const var_result<T,Str> &s
     internal::check_valid(self);
     internal::serializer_sentry group(s, key);
 
-    serialize(s, "@size", self.store_->data_.size());
+    // serialize to uint64_t to make sure we are consistent across 32/64 bit
+    serialize(s, "@size", static_cast<uint64_t>(self.store_->data_.size()));
     serialize(s, "count", self.store_->count_);
     serialize(s, "count2", self.store_->count2_);
     s.enter("mean");
@@ -296,9 +297,12 @@ void deserialize(deserializer &s, const std::string &key, var_result<T,Str> &sel
     typedef typename var_result<T,Str>::var_type var_type;
     internal::deserializer_sentry group(s, key);
 
+    // deserialize from uint64_t
+    uint64_t new_size_des;
+    deserialize(s, "@size", new_size_des);
+
     // first deserialize the fundamentals and make sure that the target fits
-    size_t new_size;
-    deserialize(s, "@size", new_size);
+    size_t new_size = new_size_des;
     if (!self.valid() || self.size() != new_size)
         self.store_.reset(new var_data<T,Str>(new_size));
 

--- a/alea/test/stream_serializer.cpp
+++ b/alea/test/stream_serializer.cpp
@@ -20,8 +20,10 @@ public:
 
     // Store simple types
     mock_archive & operator<<(double x) { store_fundamental(x); return *this; }
-    mock_archive & operator<<(long x) { store_fundamental(x); return *this; }
-    mock_archive & operator<<(unsigned long x) { store_fundamental(x); return *this; }
+    mock_archive & operator<<(int64_t x) { store_fundamental(x); return *this; }
+    mock_archive & operator<<(uint64_t x) { store_fundamental(x); return *this; }
+    mock_archive & operator<<(int32_t x) { store_fundamental(x); return *this; }
+    mock_archive & operator<<(uint32_t x) { store_fundamental(x); return *this; }
     mock_archive & operator<<(std::complex<double> x)
     {
         *this << x.real() << x.imag();
@@ -47,8 +49,10 @@ public:
 
     // Extract simple types
     mock_archive & operator>>(double &x) { extract_fundamental(x); return *this; }
-    mock_archive & operator>>(long &x) { extract_fundamental(x); return *this; }
-    mock_archive & operator>>(unsigned long &x) { extract_fundamental(x); return *this; }
+    mock_archive & operator>>(int64_t &x) { extract_fundamental(x); return *this; }
+    mock_archive & operator>>(uint64_t &x) { extract_fundamental(x); return *this; }
+    mock_archive & operator>>(int32_t &x) { extract_fundamental(x); return *this; }
+    mock_archive & operator>>(uint32_t &x) { extract_fundamental(x); return *this; }
     mock_archive & operator>>(std::complex<double> &x) {
       double r, i;
       extract_fundamental(r);

--- a/alea/test/stream_serializer.cpp
+++ b/alea/test/stream_serializer.cpp
@@ -104,18 +104,18 @@ TEST(twogauss_serialize_case, mock_archive) {
     mock_archive archive;
 
     archive << (double)3.14
-            << (long)-123456
-            << (unsigned long)7890
+            << (int64_t)-123456
+            << (uint64_t)7890
             << std::complex<double>(0.5,0.75)
             << alps::alea::complex_op<double>(1, 2, 3, 4);
 
     double x = 0;
     archive >> x;
     EXPECT_EQ(3.14, x);
-    long l = 0;
+    int64_t l = 0;
     archive >> l;
     EXPECT_EQ(-123456, l);
-    unsigned long ul = 0;
+    uint64_t ul = 0;
     archive >> ul;
     EXPECT_EQ(7890U, ul);
     std::complex<double> c = 0;


### PR DESCRIPTION
On 32-bit system, a 32-bit size_t should be used for indexing into objects, however, we want to use 64-bit counters, because it is very conceivable that more than 1e32 measurements are accumulated in a single run.

Changes `serializer` and `reducer` interfaces accordingly.

@wistaria: since you are the one with a 32-bit system, can you please see if this compiles and all the tests pass?

Fixes: #581