### PR TITLE
Fixed Travis CI MacOS build

### DIFF
--- a/common/build/build_prereq.travis.sh
+++ b/common/build/build_prereq.travis.sh
@@ -9,7 +9,6 @@ if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
     sudo apt-get install -y --allow-unauthenticated g++-5
     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5
 else
-    brew cask uninstall oclint # TravisCI bug, see https://github.com/travis-ci/travis-ci/issues/8826#issuecomment-350103392
     brew install hdf5
     brew list
 fi


### PR DESCRIPTION
[This Travis CI workaround for MacOS](https://github.com/travis-ci/travis-ci/issues/8826#issuecomment-350103392) is [not needed anymore](https://changelog.travis-ci.com/oclint-is-removed-from-mac-builds-79270) and is causing problems.

This should close #592.