### PR TITLE
CMake machinery to do postive compilation failure testing

### DIFF
--- a/utilities/test/CMakeLists.txt
+++ b/utilities/test/CMakeLists.txt
@@ -33,3 +33,6 @@ if(ALPS_HAVE_MPI)
   alps_add_gtest(mpi_utils_env_exceptions1 PARTEST SRCS mpi_test_support)
   alps_add_gtest(mpi_utils_env_exceptions2 PARTEST SRCS mpi_test_support)
 endif()
+
+# Testing "compilation failure test" machinery
+alps_add_gtest(compilation_failure_test COMPILEFAIL)

--- a/utilities/test/compilation_failure_test.cpp
+++ b/utilities/test/compilation_failure_test.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 1998-2018 ALPS Collaboration. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ * For use in publications, see ACKNOWLEDGE.TXT
+ */
+
+/**
+   @file compilation_failure_test.cpp
+   @brief A demo and a test to test for a compilation error
+
+   Here we define a function template that accepts only floating-point arguments,
+   and verify that passing an integer argument does not compile.
+*/
+
+#include <type_traits>
+#include "gtest/gtest.h"
+
+template <typename T>
+void do_something(T& val)
+{
+    static_assert(std::is_floating_point<T>::value,
+                  "do_something(T&) requires a floating point argument");
+    val=0.0;
+}
+
+TEST(utilities, testCompilationFailure) {
+    double x=1.0;
+    do_something(x);
+    SUCCEED();
+#ifdef ALPS_TEST_EXPECT_COMPILE_FAILURE
+    // The following code should not compile:
+    int m=1;
+    do_something(m);
+    FAIL() << "This code should not have compiled";
+#endif
+}


### PR DESCRIPTION
The idea that CMake tries to build the test code at `make test` (aka `ctest`) time, and expects it to fail. If the code does not fail, the correctly written test is expected to produce an explicit failure upon running (to be recorded in GTest XML output). The fragment of the code that produces the compilation failure should be protected by
```c++
#ifdef ALPS_TEST_EXPECT_COMPILE_FAILURE
   // ... compilation failure here ...
#endif 
```
guards, so that "normal" compilation and running of the code records a successful test passing.
