### PR TITLE
Issue 296.make test mpi

### DIFF
--- a/common/cmake/ALPSEnableTests.cmake
+++ b/common/cmake/ALPSEnableTests.cmake
@@ -5,6 +5,9 @@
 # check xml output
 option(TestXMLOutput "Output tests to xml" OFF)
 
+# default number of MPI processes for MPI testing
+set(ALPS_TEST_MPI_NPROC 1 CACHE STRING "Default number of MPI processes to use for MPI-enabled tests")
+
 # Find gtest or otherwise fetch it into the build_dir/gtest
 function(UseGtest gtest_root)  
     #set (gtest_root ${ALPS_ROOT_DIR}/../common/deps/gtest-1.7.0)
@@ -123,16 +126,16 @@ function(alps_add_gtest test)
     elseif (arg_PARTEST AND ALPS_HAVE_MPI) 
         # if unspecified, we assume the standard mpi launcher, according to MPI-3.1 specs, Chapter 8.8
         # (see https://www.mpi-forum.org/docs/mpi-3.1/mpi31-report/node228.htm#Node228)
-        if (NOT MPIEXEC) 
+        if (NOT DEFINED MPIEXEC) 
             set(MPIEXEC "mpiexec")
         endif()
-        if (NOT MPIEXEC_NUMPROC_FLAG)
+        if (NOT DEFINED MPIEXEC_NUMPROC_FLAG)
             set(MPIEXEC_NUMPROC_FLAG "-n")
         endif()
 
         # we also allow test-time override of the MPI launcher and its arguments
         # (NOTE: POSIX shell is assumed)
-        set(cmd_ "/bin/sh" "-c" "\${ALPS_TEST_MPIEXEC:-${MPIEXEC}} \${ALPS_TEST_MPI_NPROC_FLAG:-${MPIEXEC_NUMPROC_FLAG}} \${ALPS_TEST_MPI_NPROC:-1} \${ALPS_TEST_MPIEXEC_PREFLAGS:-${MPIEXEC_PREFLAGS}} $<TARGET_FILE:${test}> \${ALPS_TEST_MPIEXEC_POSTFLAGS:-${MPIEXEC_POSTFLAGS}} ${test_xml_output_}")
+        set(cmd_ "/bin/sh" "-c" "\${ALPS_TEST_MPIEXEC:-${MPIEXEC}} \${ALPS_TEST_MPI_NPROC_FLAG:-${MPIEXEC_NUMPROC_FLAG}} \${ALPS_TEST_MPI_NPROC:-${ALPS_TEST_MPI_NPROC}} \${ALPS_TEST_MPIEXEC_PREFLAGS:-${MPIEXEC_PREFLAGS}} $<TARGET_FILE:${test}> \${ALPS_TEST_MPIEXEC_POSTFLAGS:-${MPIEXEC_POSTFLAGS}} ${test_xml_output_}")
     else()
         set(cmd_ $<TARGET_FILE:${test}> ${test_xml_output_})
     endif()


### PR DESCRIPTION
This commit introduces the following environment variables that affect
`make test` (or `ctest`) behavior of ALPSCore:

| Variable                      | Default                  | Usual value    | Meaning |
|----------------------------- |-------------------------|--------------------|-------------- |
| `ALPS_TEST_MPIEXEC`           | `${MPIEXEC}`             | `mpiexec`      | MPI launcher                                                      |
| `ALPS_TEST_MPI_NROC_FLAG`     | `${MPIEXEC_NUMPROC_FLAG}`| `-n`           | flag to specify the number of MPI processes                       |
| `ALPS_TEST_MPI_NPROC`         | `${ALPS_TEST_MPI_NPROC}`  | 1              | How many MPI processes to launch in MPI-enabled tests             |
| `ALPS_TEST_MPIEXEC_PREFLAGS`  | `${MPIEXEC_PREFLAGS}`    | (empty string) | MPI launcher arguments preceding the executable name              |
| `ALPS_TEST_MPIEXEC_POSTFLAGS` | `${MPIEXEC_POSTFLAGS}`   | (empty string) | MPI launcher arguments preceding the arguments for the executable |

The `${...}` above are CMake variables, normally set by `FindMPI` module.

Related: issue #211.

This should close #296.

Intended use:

**Case 1: Vanilla MPI-enabled environment.**

The command to run an MPI program using 2 processes: `mpiexec -n 2 some_test`

Setting the variables to run each MPI-enabled tests on 2 processes: `ALPS_TEST_MPI_NPROC=2 make test`

**Case 2: NERSC Cori**

(*Disclaimer:* not tested with an actual Cori run)

Users are not supposed to run `mpiexec`. One has to allocate interactive nodes first.

Allocating 2 Haswell nodes for 30 minutes: `salloc -N 2 -C haswell -q interactive -t 0:30:00`

Command to run on the allocated nodes: `srun some_test`

Setting the variables to run each MPI-enabled tests on the allocated nodes:
`ALPS_TEST_MPIEXEC=srun ALPS_TEST_MPI_NPROC=' ' ALPS_TEST_MPI_NPROC_FLAG=' ' make test`

(note the variables are assigned spaces, not empty strings!)

**Case 3: Blue Waters**

(*Disclaimer:* not tested on actual Blue Waters machine)

The `aprun` command is supposed to be used to launch parallel processes from an interactive node
(see https://bluewaters.ncsa.illinois.edu/using-aprun ).

Command to run on 16 cores, using 8 cores per node (that is, 2 nodes), placing the processes on adjacent cores:
`aprun -N 8 -d 1 -n 16 some_test`

Setting the variables to run each MPI-enabled tests with this configuration:
`ALPS_TEST_MPIEXEC=aprun ALPS_TEST_MPI_NPROC=16 ALPS_TEST_MPI_NPROC_FLAG='-N 8 -d 1 -n' make test`