### PR TITLE
Ability to decouple alps::params from alps::hdf5

### DIFF
--- a/params/CMakeLists.txt
+++ b/params/CMakeLists.txt
@@ -28,7 +28,9 @@ endif()
 add_this_package(params dict_value dictionary iniparser_interface EXTRA $<TARGET_OBJECTS:libiniparser>)
 
 add_boost()
-add_hdf5()
+if (ALPS_HAVE_ALPS_HDF5)
+    add_hdf5()
+endif()
 
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../common/deps/iniparser" "./iniparser")
 if (ALPS_BUILD_SHARED OR ALPS_BUILD_PIC)
@@ -39,7 +41,12 @@ target_include_directories(${PROJECT_NAME} PRIVATE $<TARGET_PROPERTY:libiniparse
 # This does not work in CMake 3.1:
 # target_sources(${PROJECT_NAME} PRIVATE $<TARGET_OBJECTS:libiniparser>)
 
-add_alps_package(alps-utilities alps-hdf5)
+if (ALPS_HAVE_ALPS_HDF5)
+    add_alps_package(alps-utilities alps-hdf5)
+else()
+    message("NOTE: module params will be built without HDF5 support (alps-hdf5 is disabled)")
+    add_alps_package(alps-utilities)
+endif()
 
 add_testing()
 

--- a/params/include/alps/dictionary.hpp
+++ b/params/include/alps/dictionary.hpp
@@ -79,11 +79,13 @@ namespace alps {
             /// Compare two dictionaries (true if all entries are of the same type and value)
             bool equals(const dictionary& rhs) const;
 
+#ifdef ALPS_HAVE_ALPS_HDF5
             /// Save the dictionary to an archive
             void save(alps::hdf5::archive& ar) const;
 
             /// Load the dictionary from an archive
             void load(alps::hdf5::archive& ar);
+#endif
 
             friend std::ostream& operator<<(std::ostream&, const dictionary&);
 

--- a/params/include/alps/params.hpp
+++ b/params/include/alps/params.hpp
@@ -8,7 +8,10 @@
 #define ALPS_PARAMS_HPP_INCLUDED_00f672a032d949a7aa0e760a6b6f0602
 
 #include "alps/config.hpp"
+#ifdef ALPS_HAVE_ALPS_HDF5
 #include "alps/hdf5/archive.hpp"
+#endif
+
 #include <alps/utilities/deprecated.hpp>
 
 
@@ -299,11 +302,13 @@ namespace alps {
 
             friend void swap(params& p1, params& p2);
 
+#ifdef ALPS_HAVE_ALPS_HDF5
             /// Saves parameter object to an archive
             void save(alps::hdf5::archive&) const;
 
             /// Loads parameter object form an archive
             void load(alps::hdf5::archive&);
+#endif
 
             /// Prints parameters to a stream in an unspecified format
             friend

--- a/params/include/alps/params/dict_types.hpp
+++ b/params/include/alps/params/dict_types.hpp
@@ -18,11 +18,12 @@
 #include <boost/mpl/contains.hpp>
 
 
-
+#ifdef ALPS_HAVE_ALPS_HDF5
 // forward declarations
 namespace alps{ namespace hdf5 {
     class archive;
 }}
+#endif
 
 namespace alps {
     namespace params_ns {
@@ -34,8 +35,10 @@ namespace alps {
 
             /// "Empty value" type
             struct None {
+#ifdef ALPS_HAVE_ALPS_HDF5
                 void save(alps::hdf5::archive&) const { throw std::logic_error("None::save() should never be called"); }
                 void load(alps::hdf5::archive&) { throw std::logic_error("None::load() should never be called"); }
+#endif
             };
             template <typename S>
             inline S& operator<<(S&, const None&) { throw std::logic_error("Generic streaming operator of None should never be called"); }

--- a/params/include/alps/params/dict_value.hpp
+++ b/params/include/alps/params/dict_value.hpp
@@ -46,7 +46,9 @@
 #include "./dict_exceptions.hpp"
 #include "./dict_types.hpp" // Sequences of supported types
 
+#ifdef ALPS_HAVE_ALPS_HDF5
 #include <alps/hdf5/archive.hpp>
+#endif
 
 #ifdef ALPS_HAVE_MPI
 #include <alps/utilities/mpi.hpp>
@@ -125,11 +127,13 @@ namespace alps {
             /// Returns true if the objects hold the same type and value, false otherwise
             bool equals(const dict_value& rhs) const;
 
+#ifdef ALPS_HAVE_ALPS_HDF5
             /// Saves the value to an archive
             void save(alps::hdf5::archive& ar) const;
 
             /// Loads the value from an archive
             void load(alps::hdf5::archive& ar);
+#endif
 
             /// Const-access visitor to the bound value
             /** @param visitor functor should be callable as `R result=visitor(bound_value_const_ref)`

--- a/params/src/dict_value.cpp
+++ b/params/src/dict_value.cpp
@@ -9,8 +9,11 @@
 
 #include <boost/version.hpp>
 
+#include <alps/config.hpp>
 #include <alps/params/dict_value.hpp>
+#ifdef ALPS_HAVE_ALPS_HDF5
 #include <alps/params/hdf5_variant.hpp>
+#endif
 
 #ifdef ALPS_HAVE_MPI
 #include <alps/params/mpi_variant.hpp>
@@ -112,6 +115,7 @@ namespace alps {
             return boost::apply_visitor(detail::visitor::equals2(), val_, rhs.val_);
         }
 
+#ifdef ALPS_HAVE_ALPS_HDF5
         void dict_value::save(alps::hdf5::archive& ar) const {
             if (this->empty()) return;
             alps::hdf5::write_variant<detail::dict_all_types>(ar, val_);
@@ -124,6 +128,7 @@ namespace alps {
             name_=context.substr(slash_pos);
             val_=alps::hdf5::read_variant<detail::dict_all_types>(ar);
         }
+#endif
 
         namespace {
             struct typestring_visitor : public boost::static_visitor<std::string> {

--- a/params/src/dictionary.cpp
+++ b/params/src/dictionary.cpp
@@ -9,7 +9,9 @@
 
 #include <alps/dictionary.hpp>
 
+#ifdef ALPS_HAVE_ALPS_HDF5
 #include <alps/hdf5/map.hpp>
+#endif
 
 #ifdef ALPS_HAVE_MPI
 #include <alps/utilities/mpi_map.hpp>
@@ -26,7 +28,7 @@ namespace alps {
                 return map_.end();
         }
 
-        
+
         /// Access with intent to assign
         dictionary::value_type& dictionary::operator[](const std::string& key) {
             map_type::iterator it=map_.lower_bound(key);
@@ -59,14 +61,15 @@ namespace alps {
             };
 
         }
-        
-        bool dictionary::equals(const dictionary &rhs) const 
+
+        bool dictionary::equals(const dictionary &rhs) const
         {
             if (this->size()!=rhs.size()) return false;
             return std::equal(map_.begin(), map_.end(), rhs.map_.begin(), compare<map_type>());
         }
 
 
+#ifdef ALPS_HAVE_ALPS_HDF5
         void dictionary::save(alps::hdf5::archive& ar) const
         {
             ar[""] << map_;
@@ -76,10 +79,11 @@ namespace alps {
         {
             map_type new_map;
             ar[""] >> new_map;
-            
+
             using std::swap;
             swap(map_,new_map);
         }
+#endif
 
         std::ostream& operator<<(std::ostream& s, const dictionary& d)
         {
@@ -91,7 +95,7 @@ namespace alps {
 
 #ifdef ALPS_HAVE_MPI
         // Defined here to avoid including <mpi_map.hpp> inside user header
-        void dictionary::broadcast(const alps::mpi::communicator& comm, int root) { 
+        void dictionary::broadcast(const alps::mpi::communicator& comm, int root) {
             using alps::mpi::broadcast;
             broadcast(comm, map_, root);
         }

--- a/params/src/params.cpp
+++ b/params/src/params.cpp
@@ -23,8 +23,10 @@
 #include <alps/utilities/temporary_filename.hpp> // FIXME!!! Temporary!
 #include <fstream>
 
+#ifdef ALPS_HAVE_ALPS_HDF5
 #include <alps/hdf5/map.hpp>
 #include <alps/hdf5/vector.hpp>
+#endif
 
 
 #ifdef ALPS_HAVE_MPI
@@ -37,6 +39,7 @@ namespace alps {
     namespace params_ns {
 
         namespace {
+#ifdef ALPS_HAVE_ALPS_HDF5
             // Helper function to try to open an HDF5 archive, return "none" if it fails
             boost::optional<alps::hdf5::archive> try_open_ar(const std::string& fname, const char* mode)
             {
@@ -55,6 +58,7 @@ namespace alps {
                     return boost::none;
                 }
             };
+#endif
 
 
             // Helper function to read INI file into the provided map
@@ -280,6 +284,7 @@ namespace alps {
                         }
                         if (0==key_begin && npos==key_end) {
                             if (hdf5_path) {
+#ifdef ALPS_HAVE_ALPS_HDF5
                                 optional<alps::hdf5::archive> maybe_ar=try_open_ar(arg, "r");
                                 if (maybe_ar) {
                                     if (restored_from_archive) {
@@ -292,6 +297,7 @@ namespace alps {
                                     restored_from_archive=arg;
                                     continue;
                                 }
+#endif
                             }
 
                             ini_files.push_back(arg);
@@ -371,6 +377,7 @@ namespace alps {
         }
 
 
+#ifdef ALPS_HAVE_ALPS_HDF5
         void params::save(alps::hdf5::archive& ar) const {
             dictionary::save(ar);
             const std::string context=ar.get_context();
@@ -457,6 +464,7 @@ namespace alps {
             using std::swap;
             swap(*this, newpar);
         }
+#endif
 
         namespace {
             // Printing of a vector

--- a/params/test/CMakeLists.txt
+++ b/params/test/CMakeLists.txt
@@ -16,11 +16,16 @@ set (test_src
   dictval_eq  
   dictionary_eq
   params_eq
-  dictionary_hdf5
-  params_hdf5
-  params_hdf5_with_ini
-  params_vec_hdf5
   )
+
+if(ALPS_HAVE_ALPS_HDF5)
+    set(test_src
+        ${test_src}
+        dictionary_hdf5
+        params_hdf5
+        params_hdf5_with_ini
+        params_vec_hdf5)
+endif()
 
 foreach(test ${test_src})
     alps_add_gtest(${test})


### PR DESCRIPTION
This PR conditionally decouples `alps::params` from `alps::hdf5`. Specifically, if ALPSCore is built with
`-DALPS_MODULES_DISABLE=hdf5`, the `params` module will be built without archive support. This is useful if all I need from ALPSCore is its `utilities` and `params` modules.

The disadvantage is that the version of ALPSCore build like this is not compatible with the "regular" ALPSCore (e.g., it has different definition of the `alps::params` class).

This PR partially addresses issue #572.
