### PR TITLE
Elevate ALEA (`de`)`serializer` interface to common.

### DIFF
--- a/alea/include/alps/alea/core.hpp
+++ b/alea/include/alps/alea/core.hpp
@@ -18,7 +18,10 @@
 #include <alps/alea/complex_op.hpp>
 
 #include <alps/common/view.hpp>
-#include <alps/common/serialize.hpp>
+
+#include <alps/serialization/core.hpp>
+#include <alps/serialization/eigen.hpp>
+#include <alps/serialization/util.hpp>
 
 namespace alps { namespace alea {
 
@@ -54,12 +57,12 @@ template<typename T> struct is_alea_result : std::false_type {};
 // import for backwards-compatibility
 template <typename T> using view = alps::common::view<T>;
 template <typename T> using ndview = alps::common::ndview<T>;
-using serializer = alps::common::serializer;
-using deserializer = alps::common::deserializer;
+using serializer = alps::serialization::serializer;
+using deserializer = alps::serialization::deserializer;
 
 namespace internal {
-    using serializer_sentry = alps::common::serializer_sentry;
-    using deserializer_sentry = alps::common::deserializer_sentry;
+    using serializer_sentry = alps::serialization::serializer_sentry;
+    using deserializer_sentry = alps::serialization::deserializer_sentry;
 }
 
 /**

--- a/alea/include/alps/alea/hdf5.hpp
+++ b/alea/include/alps/alea/hdf5.hpp
@@ -49,10 +49,6 @@ public:
         do_write(key, value);
     }
 
-    void write(const std::string &key, ndview<const complex_op<double>> value) override {
-        throw unsupported_operation();  // FIXME
-    }
-
     void write(const std::string &key, ndview<const int64_t> value) override {
         do_write(key, value);
     }
@@ -81,10 +77,6 @@ public:
 
     void read(const std::string &key, ndview<std::complex<double>> value) override {
         do_read(key, value);
-    }
-
-    void read(const std::string &key, ndview<complex_op<double>> value) override {
-        throw unsupported_operation();  // FIXME
     }
 
     void read(const std::string &key, ndview<int64_t> value) override {

--- a/alea/include/alps/alea/plugin/stream_serializer.hpp
+++ b/alea/include/alps/alea/plugin/stream_serializer.hpp
@@ -49,10 +49,6 @@ public:
     {
         do_write(data_view);
     }
-    void write(const std::string &, ndview<const complex_op<double>> data_view) override
-    {
-        do_write(data_view);
-    }
     void write(const std::string &, ndview<const int64_t> data_view) override
     {
         do_write(data_view);
@@ -120,10 +116,6 @@ public:
         do_read(value);
     }
     void read(const std::string &, ndview<std::complex<double>> value) override
-    {
-        do_read(value);
-    }
-    void read(const std::string &, ndview<complex_op<double>> value) override
     {
         do_read(value);
     }

--- a/alea/include/alps/alea/serialize.hpp
+++ b/alea/include/alps/alea/serialize.hpp
@@ -9,183 +9,18 @@
 
 #include <array>
 
-namespace alps { namespace alea { namespace internal {
 
-/**
- * Allows RAII-type use of groups.
- */
-struct serializer_sentry
-{
-    serializer_sentry(serializer &ser, const std::string &group)
-        : ser_(ser)
-        , group_(group)
-    {
-        if (group != "")
-            ser_.enter(group);
-    }
-
-    ~serializer_sentry()
-    {
-        if (group_ != "")
-            ser_.exit();
-    }
-
-private:
-    serializer &ser_;
-    std::string group_;
-};
-
-/**
- * Allows RAII-type use of groups.
- */
-struct deserializer_sentry
-{
-    deserializer_sentry(deserializer &ser, const std::string &group)
-        : ser_(ser)
-        , group_(group)
-    {
-        if (group != "")
-            ser_.enter(group);
-    }
-
-    ~deserializer_sentry()
-    {
-        if (group_ != "")
-            ser_.exit();
-    }
-
-private:
-    deserializer &ser_;
-    std::string group_;
-};
-
-/** Helper function for serialization of scalars */
-template <typename T>
-void scalar_serialize(serializer &ser, const std::string &key, T value)
-{
-    ser.write(key, ndview<const T>(&value, nullptr, 0));
-}
-
-/** Helper function for deserialization of scalars */
-template <typename T>
-T scalar_deserialize(deserializer &ser, const std::string &key)
-{
-    T value;
-    ser.read(key, ndview<T>(&value, nullptr, 0));
-    return value;
-}
-
-/** Helper function for deserialization of scalars */
-template <typename T>
-void scalar_deserialize(deserializer &ser, const std::string &key, T &value)
-{
-    ser.read(key, ndview<T>(&value, nullptr, 0));
-}
-
-}}}
-
-namespace alps { namespace alea {
+namespace alps { namespace common {
 
 // Serialization methods
 
-inline void serialize(serializer &ser, const std::string &key, uint32_t value) {
-    internal::scalar_serialize(ser, key, value);
-}
-inline void serialize(serializer &ser, const std::string &key, int32_t value) {
-    internal::scalar_serialize(ser, key, value);
-}
-inline void serialize(serializer &ser, const std::string &key, uint64_t value) {
-    internal::scalar_serialize(ser, key, value);
-}
-inline void serialize(serializer &ser, const std::string &key, int64_t value) {
-    internal::scalar_serialize(ser, key, value);
-}
-inline void serialize(serializer &ser, const std::string &key, double value) {
-    internal::scalar_serialize(ser, key, value);
-}
-inline void serialize(serializer &ser, const std::string &key,
-                      std::complex<double> value) {
-    internal::scalar_serialize(ser, key, value);
-}
 
-template <typename Derived>
-void serialize(serializer &ser, const std::string &key,
-               const Eigen::MatrixBase<Derived> &value)
-{
-    typedef Eigen::internal::traits<Derived> traits;
-    typedef typename traits::Scalar scalar_type;
-    typedef Eigen::Matrix<scalar_type, Derived::RowsAtCompileTime,
-                          Derived::ColsAtCompileTime> plain_matrix_type;
 
-    // Ensure that evaluated expression will be continuous
-    if ((Derived::MaxRowsAtCompileTime != Eigen::Dynamic
-                    && Derived::MaxRowsAtCompileTime != value.rows())
-            || (Derived::MaxColsAtCompileTime != Eigen::Dynamic
-                    && Derived::MaxColsAtCompileTime != value.cols())
-            || ((Derived::Options & Eigen::RowMajor)
-                    && value.rows() != 1 && value.cols() != 1))
-        serialize(ser, key, plain_matrix_type(value));
-
-    // Evaluate to matrix or proxy object if already matrix
-    auto temp = value.eval();
-
-    if (Derived::ColsAtCompileTime == 1 || Derived::RowsAtCompileTime == 1) {
-        // Omit second dimension for simple vectors
-        std::array<size_t, 1> dims = {{(size_t)temp.size()}};
-        ser.write(key, ndview<const scalar_type>(temp.data(), dims.data(), 1));
-    } else {
-        // Eigen arrays are column-major
-        std::array<size_t, 2> dims = {{(size_t)temp.cols(), (size_t)temp.rows()}};
-        ser.write(key, ndview<const scalar_type>(temp.data(), dims.data(), 2));
-    }
-}
 
 
 // Argument-oriented deserialization
 
-inline void deserialize(deserializer &ser, const std::string &key, uint64_t &value) {
-    internal::scalar_deserialize(ser, key, value);
-}
-inline void deserialize(deserializer &ser, const std::string &key, int64_t &value) {
-    internal::scalar_deserialize(ser, key, value);
-}
-inline void deserialize(deserializer &ser, const std::string &key, uint32_t &value) {
-    internal::scalar_deserialize(ser, key, value);
-}
-inline void deserialize(deserializer &ser, const std::string &key, int32_t &value) {
-    internal::scalar_deserialize(ser, key, value);
-}
-inline void deserialize(deserializer &ser, const std::string &key, double &value) {
-    internal::scalar_deserialize(ser, key, value);
-}
-inline void deserialize(deserializer &ser, const std::string &key,
-                        std::complex<double> &value) {
-    internal::scalar_deserialize(ser, key, value);
-}
 
-template <typename T>
-void deserialize(deserializer &ser, const std::string &key,
-                 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> &value)
-{
-    std::array<size_t, 2> shape = {{(size_t)value.cols(), (size_t)value.rows()}};
-    ser.read(key, ndview<T>(value.data(), shape.data(), shape.size()));
-}
-
-template <typename T>
-void deserialize(deserializer &ser, const std::string &key,
-                 Eigen::Matrix<T, Eigen::Dynamic, 1> &value)
-{
-    std::array<size_t, 1> shape = {{(size_t)value.rows()}};
-    ser.read(key, ndview<T>(value.data(), shape.data(), shape.size()));
-}
-
-template <typename T>
-void deserialize(deserializer &ser, const std::string &key,
-                 Eigen::Matrix<T, 1, Eigen::Dynamic> &value)
-{
-    std::array<size_t, 1> shape = {{(size_t)value.cols()}};
-    ser.read(key, ndview<T>(value.data(), shape.data(), shape.size()));
-}
 
 
 }}

--- a/alea/include/alps/alea/serialize.hpp
+++ b/alea/include/alps/alea/serialize.hpp
@@ -36,7 +36,7 @@ serialize(serializer &ser, const std::string &key,
         ser.write(key, ndview<const double>(dbl_data, dims.data(), dims.size()));
     } else {
         // Eigen arrays are column-major
-        std::array<size_t, 4> dims = {{(size_t)value.cols(), value.rows(), 2, 2}};
+        std::array<size_t, 4> dims = {{(size_t)value.cols(), (size_t)value.rows(), 2, 2}};
         ser.write(key, ndview<const double>(dbl_data, dims.data(), dims.size()));
     }
 }

--- a/alea/include/alps/alea/serialize.hpp
+++ b/alea/include/alps/alea/serialize.hpp
@@ -12,8 +12,42 @@
 
 #include <array>
 
-namespace alps { namespace common {
+namespace alps { namespace serialization {
 
-// TODO
+template <typename Derived>
+typename std::enable_if<
+        eigen_scalar_is<Derived, alps::alea::complex_op<double>>::value>::type
+serialize(serializer &ser, const std::string &key,
+          const Eigen::MatrixBase<Derived> &value)
+{
+    throw std::runtime_error("serializing complex_op matrices not implemented.");
+}
+
+template <typename T>
+typename std::enable_if<
+            std::is_same<T, alps::alea::complex_op<double>>::value>::type
+deserialize(deserializer &ser, const std::string &key,
+            Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> &value)
+{
+    throw std::runtime_error("serializing complex_op matrices not implemented.");
+}
+
+template <typename T>
+typename std::enable_if<
+            std::is_same<T, alps::alea::complex_op<double>>::value>::type
+deserialize(deserializer &ser, const std::string &key,
+            Eigen::Matrix<T, Eigen::Dynamic, 1> &value)
+{
+    throw std::runtime_error("serializing complex_op matrices not implemented.");
+}
+
+template <typename T>
+typename std::enable_if<
+            std::is_same<T, alps::alea::complex_op<double>>::value>::type
+deserialize(deserializer &ser, const std::string &key,
+            Eigen::Matrix<T, 1, Eigen::Dynamic> &value)
+{
+    throw std::runtime_error("serializing complex_op matrices not implemented.");
+}
 
 }}

--- a/alea/include/alps/alea/serialize.hpp
+++ b/alea/include/alps/alea/serialize.hpp
@@ -6,21 +6,14 @@
 #pragma once
 
 #include <alps/alea/core.hpp>
+#include <alps/serialization/core.hpp>
+#include <alps/serialization/util.hpp>
+#include <alps/serialization/eigen.hpp>
 
 #include <array>
 
-
 namespace alps { namespace common {
 
-// Serialization methods
-
-
-
-
-
-// Argument-oriented deserialization
-
-
-
+// TODO
 
 }}

--- a/alea/include/alps/alea/serialize.hpp
+++ b/alea/include/alps/alea/serialize.hpp
@@ -14,40 +14,57 @@
 
 namespace alps { namespace serialization {
 
+/** Serializes Eigen array of complex_op<double> */
 template <typename Derived>
 typename std::enable_if<
         eigen_scalar_is<Derived, alps::alea::complex_op<double>>::value>::type
 serialize(serializer &ser, const std::string &key,
-          const Eigen::MatrixBase<Derived> &value)
+          const Eigen::PlainObjectBase<Derived> &value)
 {
-    throw std::runtime_error("serializing complex_op matrices not implemented.");
+    using scalar_type = eigen_scalar_t<Derived>;
+    using matrix_type = Eigen::Matrix<scalar_type, Eigen::Dynamic, Eigen::Dynamic>;
+
+    // Ensure that evaluated expression will be Fortran-contiguous
+    if (!eigen_is_contiguous(value))
+        serialize(ser, key, matrix_type(value));
+
+    // Evaluate to matrix or proxy object if already matrix
+    const double *dbl_data = reinterpret_cast<const double *>(value.data());
+    if (Derived::ColsAtCompileTime == 1 || Derived::RowsAtCompileTime == 1) {
+        // Omit second dimension for simple vectors
+        std::array<size_t, 3> dims = {{(size_t)value.size(), 2, 2}};
+        ser.write(key, ndview<const double>(dbl_data, dims.data(), dims.size()));
+    } else {
+        // Eigen arrays are column-major
+        std::array<size_t, 4> dims = {{(size_t)value.cols(), value.rows(), 2, 2}};
+        ser.write(key, ndview<const double>(dbl_data, dims.data(), dims.size()));
+    }
 }
 
-template <typename T>
+/** Deserializes Eigen array or matrix of complex_op<double> */
+template <typename Derived>
 typename std::enable_if<
-            std::is_same<T, alps::alea::complex_op<double>>::value>::type
+        eigen_scalar_is<Derived, alps::alea::complex_op<double>>::value>::type
 deserialize(deserializer &ser, const std::string &key,
-            Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> &value)
+            Eigen::PlainObjectBase<Derived> &value)
 {
-    throw std::runtime_error("serializing complex_op matrices not implemented.");
-}
+    // Ensure that evaluated expression will be Fortran-contiguous
+    if (!eigen_is_contiguous(value)) {
+        throw std::runtime_error("Unable to read to array: "
+                                 "it must be Fortran contiguous in memory");
+    }
 
-template <typename T>
-typename std::enable_if<
-            std::is_same<T, alps::alea::complex_op<double>>::value>::type
-deserialize(deserializer &ser, const std::string &key,
-            Eigen::Matrix<T, Eigen::Dynamic, 1> &value)
-{
-    throw std::runtime_error("serializing complex_op matrices not implemented.");
-}
-
-template <typename T>
-typename std::enable_if<
-            std::is_same<T, alps::alea::complex_op<double>>::value>::type
-deserialize(deserializer &ser, const std::string &key,
-            Eigen::Matrix<T, 1, Eigen::Dynamic> &value)
-{
-    throw std::runtime_error("serializing complex_op matrices not implemented.");
+    // Evaluate to matrix or proxy object if already matrix
+    double *dbl_data = reinterpret_cast<double *>(value.data());
+    if (Derived::ColsAtCompileTime == 1 || Derived::RowsAtCompileTime == 1) {
+        // Omit second dimension for simple vectors
+        std::array<size_t, 3> shape = {{(size_t)value.size(), 2, 2}};
+        ser.read(key, ndview<double>(dbl_data, shape.data(), shape.size()));
+    } else {
+        // Extract underlying buffer and read
+        std::array<size_t, 4> shape = {{(size_t)value.cols(), (size_t)value.rows(), 2, 2}};
+        ser.read(key, ndview<double>(dbl_data, shape.data(), shape.size()));
+    }
 }
 
 }}

--- a/alea/include/alps/alea/util/serializer.hpp
+++ b/alea/include/alps/alea/util/serializer.hpp
@@ -24,8 +24,6 @@ public:
 
     void write(const std::string &, ndview<const std::complex<double>>) override { }
 
-    void write(const std::string &, ndview<const complex_op<double>>) override { }
-
     void write(const std::string &, ndview<const int64_t>) override { }
 
     void write(const std::string &, ndview<const uint64_t>) override { }
@@ -73,10 +71,6 @@ public:
     }
 
     void write(const std::string &key, ndview<const std::complex<double>> value) override {
-        do_write(key, value);
-    }
-
-    void write(const std::string &key, ndview<const complex_op<double>> value) override {
         do_write(key, value);
     }
 

--- a/alea/src/covariance.cpp
+++ b/alea/src/covariance.cpp
@@ -281,9 +281,11 @@ void serialize(serializer &s, const std::string &key, const cov_result<T,Str> &s
     serialize(s, "count2", self.store_->count2_);
     s.enter("mean");
     serialize(s, "value", self.store_->data_);
-    serialize(s, "error", self.stderror());   // TODO temporary
+    // FIXME complex_op
+    // serialize(s, "error", self.stderror());   // TODO temporary
     s.exit();
-    serialize(s, "cov", self.store_->data2_);
+    // FIXME complex_op
+    // serialize(s, "cov", self.store_->data2_);
 }
 
 template <typename T, typename Str>
@@ -306,9 +308,11 @@ void deserialize(deserializer &s, const std::string &key, cov_result<T,Str> &sel
     deserialize(s, "count2", self.store_->count2_);
     s.enter("mean");
     deserialize(s, "value", self.store_->data_);
-    s.read("error", ndview<var_type>(nullptr, &new_size, 1)); // discard
+    // FIXME complex_op
+    // s.read("error", ndview<var_type>(nullptr, &new_size, 1)); // discard
     s.exit();
-    deserialize(s, "cov", self.store_->data2_);
+    // FIXME complex_op
+    // deserialize(s, "cov", self.store_->data2_);
 }
 
 template void serialize(serializer &, const std::string &key, const cov_result<double, circular_var> &);

--- a/alea/src/covariance.cpp
+++ b/alea/src/covariance.cpp
@@ -281,11 +281,9 @@ void serialize(serializer &s, const std::string &key, const cov_result<T,Str> &s
     serialize(s, "count2", self.store_->count2_);
     s.enter("mean");
     serialize(s, "value", self.store_->data_);
-    // FIXME complex_op
-    // serialize(s, "error", self.stderror());   // TODO temporary
+    serialize(s, "error", self.stderror());   // TODO temporary
     s.exit();
-    // FIXME complex_op
-    // serialize(s, "cov", self.store_->data2_);
+    serialize(s, "cov", self.store_->data2_);
 }
 
 template <typename T, typename Str>
@@ -308,11 +306,10 @@ void deserialize(deserializer &s, const std::string &key, cov_result<T,Str> &sel
     deserialize(s, "count2", self.store_->count2_);
     s.enter("mean");
     deserialize(s, "value", self.store_->data_);
-    // FIXME complex_op
-    // s.read("error", ndview<var_type>(nullptr, &new_size, 1)); // discard
+    Eigen::Matrix<var_type, Eigen::Dynamic, 1> discard(self.size());
+    deserialize(s, "error", discard);
     s.exit();
-    // FIXME complex_op
-    // deserialize(s, "cov", self.store_->data2_);
+    deserialize(s, "cov", self.store_->data2_);
 }
 
 template void serialize(serializer &, const std::string &key, const cov_result<double, circular_var> &);

--- a/alea/src/variance.cpp
+++ b/alea/src/variance.cpp
@@ -286,11 +286,9 @@ void serialize(serializer &s, const std::string &key, const var_result<T,Str> &s
     serialize(s, "count2", self.store_->count2_);
     s.enter("mean");
     serialize(s, "value", self.store_->data_);
-    // FIXME: complex_op
-    // serialize(s, "error", self.stderror());   // TODO temporary
+    serialize(s, "error", self.stderror());   // TODO temporary
     s.exit();
-    // FIXME: complex_op
-    // serialize(s, "var", self.store_->data2_);
+    serialize(s, "var", self.store_->data2_);
 }
 
 template <typename T, typename Str>
@@ -313,11 +311,10 @@ void deserialize(deserializer &s, const std::string &key, var_result<T,Str> &sel
     deserialize(s, "count2", self.store_->count2_);
     s.enter("mean");
     deserialize(s, "value", self.store_->data_);
-    // FIXME complexop
-    //s.read("error", ndview<var_type>(nullptr, &new_size, 1)); // discard
+    Eigen::Matrix<var_type, Eigen::Dynamic, 1> discard(self.size());
+    deserialize(s, "error", discard); // discard
     s.exit();
-    // FIXME: complex_op
-    // deserialize(s, "var", self.store_->data2_);
+    deserialize(s, "var", self.store_->data2_);
 }
 
 template void serialize(serializer &, const std::string &key, const var_result<double, circular_var> &);

--- a/alea/src/variance.cpp
+++ b/alea/src/variance.cpp
@@ -286,9 +286,11 @@ void serialize(serializer &s, const std::string &key, const var_result<T,Str> &s
     serialize(s, "count2", self.store_->count2_);
     s.enter("mean");
     serialize(s, "value", self.store_->data_);
-    serialize(s, "error", self.stderror());   // TODO temporary
+    // FIXME: complex_op
+    // serialize(s, "error", self.stderror());   // TODO temporary
     s.exit();
-    serialize(s, "var", self.store_->data2_);
+    // FIXME: complex_op
+    // serialize(s, "var", self.store_->data2_);
 }
 
 template <typename T, typename Str>
@@ -311,9 +313,11 @@ void deserialize(deserializer &s, const std::string &key, var_result<T,Str> &sel
     deserialize(s, "count2", self.store_->count2_);
     s.enter("mean");
     deserialize(s, "value", self.store_->data_);
-    s.read("error", ndview<var_type>(nullptr, &new_size, 1)); // discard
+    // FIXME complexop
+    //s.read("error", ndview<var_type>(nullptr, &new_size, 1)); // discard
     s.exit();
-    deserialize(s, "var", self.store_->data2_);
+    // FIXME: complex_op
+    // deserialize(s, "var", self.store_->data2_);
 }
 
 template void serialize(serializer &, const std::string &key, const var_result<double, circular_var> &);

--- a/alea/test/stream_serializer.cpp
+++ b/alea/test/stream_serializer.cpp
@@ -30,14 +30,6 @@ public:
         return *this;
     }
 
-    // Store complex_op<T>
-    template<typename T>
-    mock_archive & operator<<(const alps::alea::complex_op<T> &x)
-    {
-        *this << x.rere() << x.reim() << x.imre() << x.imim();
-        return *this;
-    }
-
     // Store ALEA results
     template <typename T>
     typename std::enable_if<alps::alea::is_alea_result<T>::value, mock_archive &>::type
@@ -59,14 +51,6 @@ public:
       extract_fundamental(i);
       x = std::complex<double>(r, i);
       return *this;
-    }
-
-    // Extract complex_op<T>
-    template<typename T>
-    mock_archive & operator>>(alps::alea::complex_op<T> &x)
-    {
-        *this >> x.rere() >> x.reim() >> x.imre() >> x.imim();
-        return *this;
     }
 
     // Extract ALEA results
@@ -107,7 +91,8 @@ TEST(twogauss_serialize_case, mock_archive) {
             << (int64_t)-123456
             << (uint64_t)7890
             << std::complex<double>(0.5,0.75)
-            << alps::alea::complex_op<double>(1, 2, 3, 4);
+            //<< alps::alea::complex_op<double>(1, 2, 3, 4)
+            ;
 
     double x = 0;
     archive >> x;
@@ -121,9 +106,9 @@ TEST(twogauss_serialize_case, mock_archive) {
     std::complex<double> c = 0;
     archive >> c;
     EXPECT_EQ(std::complex<double>(0.5,0.75), c);
-    alps::alea::complex_op<double> co(0, 0, 0, 0);
-    archive >> co;
-    EXPECT_EQ(alps::alea::complex_op<double>(1, 2, 3, 4), co);
+    //alps::alea::complex_op<double> co(0, 0, 0, 0);
+    //archive >> co;
+    //EXPECT_EQ(alps::alea::complex_op<double>(1, 2, 3, 4), co);
 }
 
 template <typename Acc>

--- a/utilities/include/alps/common/serialize.hpp
+++ b/utilities/include/alps/common/serialize.hpp
@@ -1,0 +1,306 @@
+/*
+ * Copyright (C) 1998-2018 ALPS Collaboration. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ * For use in publications, see ACKNOWLEDGE.TXT
+ */
+#pragma once
+
+#include <cstddef>
+#include <cassert>
+#include <string>
+#include <complex>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include <alps/common/view.hpp>
+
+namespace alps { namespace common {
+
+/** Class does not support this operation */
+struct unsupported_serializer_clone : public std::exception { };
+
+/**
+ * Foster the serialization of data to disk.
+ *
+ * The serialization interface writes a hierarchy of named groups, traversed by
+ * `enter()` and `exit()`, each containing a set of primitives or key-value
+ * pairs, written by the `write()` family of methods.
+ *
+ * @see alps::alea::serialize(), alps::alea::deserializer
+ */
+struct serializer
+{
+    /** Creates and descends into a group with name `group` */
+    virtual void enter(const std::string &group) = 0;
+
+    /** Ascends from the lowermost group */
+    virtual void exit() = 0;
+
+    /** Writes a named multi-dimensional array of doubles */
+    virtual void write(const std::string &key, ndview<const double>) = 0;
+
+    /** Writes a named multi-dimensional array of complex doubles */
+    virtual void write(const std::string &key, ndview<const std::complex<double>>) = 0;
+
+    /** Writes a named multi-dimensional array of longs */
+    virtual void write(const std::string &key, ndview<const int64_t>) = 0;
+
+    /** Writes a named multi-dimensional array of unsigned longs */
+    virtual void write(const std::string &key, ndview<const uint64_t>) = 0;
+
+    /** Writes a named multi-dimensional array of int */
+    virtual void write(const std::string &key, ndview<const int32_t>) = 0;
+
+    /** Writes a named multi-dimensional array of unsigned int */
+    virtual void write(const std::string &key, ndview<const uint32_t>) = 0;
+
+    /** Returns a copy of `*this` created using `new` */
+    virtual serializer *clone() { throw unsupported_serializer_clone(); }
+
+    /** Destructor */
+    virtual ~serializer() { }
+};
+
+/**
+ * Foster the deserialization of data from disk.
+ *
+ * The serialization interface writes a hierarchy of named groups, traversed by
+ * `enter()` and `exit()`, each containing a set of primitives or key-value
+ * pairs, read out by the `read()` family of methods.
+ *
+ * Each `read()` method read to the `ndview::data()` buffer, if given.  If
+ * that field is `nullptr`, it shall instead read but discard the data.
+ *
+ * @see alps::alea::deserialize(), alps::alea::serializer
+ */
+struct deserializer
+{
+    /** Descends into a group with name `group` */
+    virtual void enter(const std::string &group) = 0;
+
+    /** Ascends from the lowermost group */
+    virtual void exit() = 0;
+
+    /** Retrieves metadata for a primitive */
+    virtual std::vector<size_t> get_shape(const std::string &key) = 0;
+
+    /** Reads a named multi-dimensional array of double */
+    virtual void read(const std::string &key, ndview<double>) = 0;
+
+    /** Reads a named multi-dimensional array of double complex */
+    virtual void read(const std::string &key, ndview<std::complex<double>>) = 0;
+
+    /** Reads a named multi-dimensional array of longs */
+    virtual void read(const std::string &key, ndview<int64_t>) = 0;
+
+    /** Reads a named multi-dimensional array of unsigned longs */
+    virtual void read(const std::string &key, ndview<uint64_t>) = 0;
+
+    /** Reads a named multi-dimensional array of int */
+    virtual void read(const std::string &key, ndview<int32_t>) = 0;
+
+    /** Reads a named multi-dimensional array of unsigned int */
+    virtual void read(const std::string &key, ndview<uint32_t>) = 0;
+
+    /** Returns a copy of `*this` created using `new` */
+    virtual deserializer *clone() { throw unsupported_serializer_clone(); }
+
+    /** Destructor */
+    virtual ~deserializer() { }
+};
+
+/**
+ * Allows RAII-type use of groups in serializer.
+ *
+ * Enters the specified group on construction of the sentry, and automatically
+ * leaves the group when the object is destroyed.  This also allows recovery in
+ * the case of soft exceptions.
+ *
+ *     void write_to_group(serializer &s, std::string name) {
+ *         internal::serializer_sentry group(s, name);
+ *         serialize(s, "first_item", 42);
+ *         serialize(s, "second_item", 4711);
+ *     } // exits group here
+ */
+struct serializer_sentry
+{
+    serializer_sentry(serializer &ser, const std::string &group)
+        : ser_(ser)
+        , group_(group)
+    {
+        if (group != "")
+            ser_.enter(group);
+    }
+
+    ~serializer_sentry()
+    {
+        if (group_ != "")
+            ser_.exit();
+    }
+
+private:
+    serializer &ser_;
+    std::string group_;
+};
+
+/**
+ * Allows RAII-type use of groups in deserializer.
+ *
+ * Enters the specified group on construction of the sentry, and automatically
+ * leaves the group when the object is destroyed.  This also allows recovery in
+ * the case of soft exceptions.
+ */
+struct deserializer_sentry
+{
+    deserializer_sentry(deserializer &ser, const std::string &group)
+        : ser_(ser)
+        , group_(group)
+    {
+        if (group != "")
+            ser_.enter(group);
+    }
+
+    ~deserializer_sentry()
+    {
+        if (group_ != "")
+            ser_.exit();
+    }
+
+private:
+    deserializer &ser_;
+    std::string group_;
+};
+
+}}
+
+namespace alps { namespace common { namespace internal {
+
+/** Helper function for serialization of scalars */
+template <typename T>
+void scalar_serialize(serializer &ser, const std::string &key, T value)
+{
+    ser.write(key, ndview<const T>(&value, nullptr, 0));
+}
+
+/** Helper function for deserialization of scalars */
+template <typename T>
+T scalar_deserialize(deserializer &ser, const std::string &key)
+{
+    T value;
+    ser.read(key, ndview<T>(&value, nullptr, 0));
+    return value;
+}
+
+/** Helper function for deserialization of scalars */
+template <typename T>
+void scalar_deserialize(deserializer &ser, const std::string &key, T &value)
+{
+    ser.read(key, ndview<T>(&value, nullptr, 0));
+}
+
+}}}
+
+namespace alps { namespace common {
+
+// Serialization methods
+
+inline void serialize(serializer &ser, const std::string &key, uint32_t value) {
+    internal::scalar_serialize(ser, key, value);
+}
+inline void serialize(serializer &ser, const std::string &key, int32_t value) {
+    internal::scalar_serialize(ser, key, value);
+}
+inline void serialize(serializer &ser, const std::string &key, uint64_t value) {
+    internal::scalar_serialize(ser, key, value);
+}
+inline void serialize(serializer &ser, const std::string &key, int64_t value) {
+    internal::scalar_serialize(ser, key, value);
+}
+inline void serialize(serializer &ser, const std::string &key, double value) {
+    internal::scalar_serialize(ser, key, value);
+}
+inline void serialize(serializer &ser, const std::string &key,
+                      std::complex<double> value) {
+    internal::scalar_serialize(ser, key, value);
+}
+
+template <typename Derived>
+void serialize(serializer &ser, const std::string &key,
+               const Eigen::MatrixBase<Derived> &value)
+{
+    typedef Eigen::internal::traits<Derived> traits;
+    typedef typename traits::Scalar scalar_type;
+    typedef Eigen::Matrix<scalar_type, Derived::RowsAtCompileTime,
+                          Derived::ColsAtCompileTime> plain_matrix_type;
+
+    // Ensure that evaluated expression will be continuous
+    if ((Derived::MaxRowsAtCompileTime != Eigen::Dynamic
+                    && Derived::MaxRowsAtCompileTime != value.rows())
+            || (Derived::MaxColsAtCompileTime != Eigen::Dynamic
+                    && Derived::MaxColsAtCompileTime != value.cols())
+            || ((Derived::Options & Eigen::RowMajor)
+                    && value.rows() != 1 && value.cols() != 1))
+        serialize(ser, key, plain_matrix_type(value));
+
+    // Evaluate to matrix or proxy object if already matrix
+    auto temp = value.eval();
+
+    if (Derived::ColsAtCompileTime == 1 || Derived::RowsAtCompileTime == 1) {
+        // Omit second dimension for simple vectors
+        std::array<size_t, 1> dims = {{(size_t)temp.size()}};
+        ser.write(key, ndview<const scalar_type>(temp.data(), dims.data(), 1));
+    } else {
+        // Eigen arrays are column-major
+        std::array<size_t, 2> dims = {{(size_t)temp.cols(), (size_t)temp.rows()}};
+        ser.write(key, ndview<const scalar_type>(temp.data(), dims.data(), 2));
+    }
+}
+
+// Argument-oriented deserialization
+
+inline void deserialize(deserializer &ser, const std::string &key, uint64_t &value) {
+    internal::scalar_deserialize(ser, key, value);
+}
+inline void deserialize(deserializer &ser, const std::string &key, int64_t &value) {
+    internal::scalar_deserialize(ser, key, value);
+}
+inline void deserialize(deserializer &ser, const std::string &key, uint32_t &value) {
+    internal::scalar_deserialize(ser, key, value);
+}
+inline void deserialize(deserializer &ser, const std::string &key, int32_t &value) {
+    internal::scalar_deserialize(ser, key, value);
+}
+inline void deserialize(deserializer &ser, const std::string &key, double &value) {
+    internal::scalar_deserialize(ser, key, value);
+}
+inline void deserialize(deserializer &ser, const std::string &key,
+                        std::complex<double> &value) {
+    internal::scalar_deserialize(ser, key, value);
+}
+
+template <typename T>
+void deserialize(deserializer &ser, const std::string &key,
+                 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> &value)
+{
+    std::array<size_t, 2> shape = {{(size_t)value.cols(), (size_t)value.rows()}};
+    ser.read(key, ndview<T>(value.data(), shape.data(), shape.size()));
+}
+
+template <typename T>
+void deserialize(deserializer &ser, const std::string &key,
+                 Eigen::Matrix<T, Eigen::Dynamic, 1> &value)
+{
+    std::array<size_t, 1> shape = {{(size_t)value.rows()}};
+    ser.read(key, ndview<T>(value.data(), shape.data(), shape.size()));
+}
+
+template <typename T>
+void deserialize(deserializer &ser, const std::string &key,
+                 Eigen::Matrix<T, 1, Eigen::Dynamic> &value)
+{
+    std::array<size_t, 1> shape = {{(size_t)value.cols()}};
+    ser.read(key, ndview<T>(value.data(), shape.data(), shape.size()));
+}
+
+}}

--- a/utilities/include/alps/common/view.hpp
+++ b/utilities/include/alps/common/view.hpp
@@ -14,10 +14,13 @@ namespace alps { namespace common {
 using std::size_t;
 
 /**
- * Data view as a thin wrapper around a continuous array.
+ * Data view as a thin wrapper around a C-contiguous array.
  *
- * Basically collects a pointer continuous array together with its size.  Note
- * that the view does not own the `data` pointer.
+ * Basically collects a pointer C-contiguous array together with its size.
+ *
+ * \warning For performance and maximal flexibility, the view does not own
+ *          the `data` pointer.  You need to make sure that the data pointer
+ *          outlives this object.
  */
 template <typename T>
 class view
@@ -49,12 +52,14 @@ private:
 };
 
 /**
- * Data view as a thin wrapper around a continuous multi-dimensional array.
+ * Data view as a thin wrapper around a C-contiguous  multi-dimensional array.
  *
- * Basically collects a pointer continuous array in ROW-MAJOR format (vector,
- * transposed Eigen array, C array etc.) together with its shape.  Note that
- * the view neither owns the `data` pointer nor the `shape` pointer.  Thus it
- * amends `view<T>` with shape information.
+ * Basically collects a pointer contiguous array in ROW-MAJOR format (vector,
+ * transposed Eigen array, C array etc.) together with its shape.
+ *
+ * \warning for performance, this class owns neither the `data` pointer nor
+ *          the `shape` pointer.  You need to make sure that both pointers
+ *          outlive this object.
  */
 template <typename T>
 class ndview

--- a/utilities/include/alps/common/view.hpp
+++ b/utilities/include/alps/common/view.hpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 1998-2018 ALPS Collaboration. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ * For use in publications, see ACKNOWLEDGE.TXT
+ */
+#pragma once
+
+#include <cstddef>
+#include <cassert>
+#include <string>
+
+namespace alps { namespace common {
+
+using std::size_t;
+
+/**
+ * Data view as a thin wrapper around a continuous array.
+ *
+ * Basically collects a pointer continuous array together with its size.  Note
+ * that the view does not own the `data` pointer.
+ */
+template <typename T>
+class view
+{
+public:
+    typedef T value_type;
+
+public:
+    /** Construct view on nothing */
+    view() : data_(nullptr), size_(0) { }
+
+    /** Construct view on data area with size */
+    view(T *data, size_t size)
+        : data_(data), size_(size)
+    { }
+
+    /** Get pointer to zeroth element */
+    T *data() { return data_; }
+
+    /** Get pointer to zeroth element */
+    const T *data() const { return data_; }
+
+    /** Return size */
+    size_t size() const { return size_; }
+
+private:
+    T *data_;
+    size_t size_;
+};
+
+/**
+ * Data view as a thin wrapper around a continuous multi-dimensional array.
+ *
+ * Basically collects a pointer continuous array in ROW-MAJOR format (vector,
+ * transposed Eigen array, C array etc.) together with its shape.  Note that
+ * the view neither owns the `data` pointer nor the `shape` pointer.  Thus it
+ * amends `view<T>` with shape information.
+ */
+template <typename T>
+class ndview
+    : public view<T>
+{
+public:
+    typedef T value_type;
+
+public:
+    /** Construct view on nothing */
+    ndview() : view<T>(), shape_(nullptr), ndim_(0) { }
+
+    /** Construct view on data area with shape */
+    ndview(T *data, const size_t *shape, size_t ndim)
+        : view<T>(data, compute_size(shape, ndim))
+        , shape_(shape)
+        , ndim_(ndim)
+    { }
+
+    /** Construct view on data area with shape and size hint */
+    ndview(T *data, size_t size, const size_t *shape, size_t ndim)
+        : view<T>(data, size)
+        , shape_(shape)
+        , ndim_(ndim)
+    {
+        assert(size == compute_size(shape, ndim));
+    }
+
+    /** Get shape of data space */
+    const size_t *shape() const { return shape_; }
+
+    /** Get number of dimensions */
+    size_t ndim() const { return ndim_; }
+
+protected:
+    static size_t compute_size(const size_t *shape, size_t ndim)
+    {
+        size_t result = 1;
+        for (size_t d = 0; d != ndim; ++d)
+            result *= shape[d];
+        return result;
+    }
+
+private:
+    const size_t *shape_;
+    size_t ndim_;
+};
+
+}}

--- a/utilities/include/alps/serialization/eigen.hpp
+++ b/utilities/include/alps/serialization/eigen.hpp
@@ -13,9 +13,21 @@
 namespace alps { namespace serialization {
 
 template <typename Derived>
+struct eigen_scalar {
+    using type = typename Eigen::internal::traits<Derived>::Scalar;
+};
+
+template <typename Derived>
+using eigen_scalar_t = typename eigen_scalar<Derived>::type;
+
+template <typename Derived>
 struct has_primitive_scalar {
-    using _scalar_type = typename Eigen::internal::traits<Derived>::Scalar;
-    static const bool value = is_primitive<_scalar_type>::value;
+    static const bool value = is_primitive<eigen_scalar_t<Derived>>::value;
+};
+
+template <typename Derived, typename T>
+struct eigen_scalar_is {
+    static const bool value = std::is_same<eigen_scalar_t<Derived>, T>::value;
 };
 
 template <typename Derived>

--- a/utilities/include/alps/serialization/eigen.hpp
+++ b/utilities/include/alps/serialization/eigen.hpp
@@ -14,24 +14,29 @@
 
 namespace alps { namespace serialization {
 
+/** Type trait that extracts the underlying scalar type of array */
 template <typename Derived>
 struct eigen_scalar {
     using type = typename Eigen::internal::traits<Derived>::Scalar;
 };
 
+/** Type trait that extracts the underlying scalar type of array */
 template <typename Derived>
 using eigen_scalar_t = typename eigen_scalar<Derived>::type;
 
+/** Underlying Eigen scalar type is a serialization primitive */
 template <typename Derived>
 struct has_primitive_scalar {
     static const bool value = is_primitive<eigen_scalar_t<Derived>>::value;
 };
 
+/** Underlying Eigen scalar type is `T` */
 template <typename Derived, typename T>
 struct eigen_scalar_is {
     static const bool value = std::is_same<eigen_scalar_t<Derived>, T>::value;
 };
 
+/** Returns true if and only if Eigen array is Fortran-contiguous */
 template <typename Derived>
 constexpr bool eigen_is_contiguous(const Eigen::PlainObjectBase<Derived> &matrix)
 {
@@ -41,6 +46,7 @@ constexpr bool eigen_is_contiguous(const Eigen::PlainObjectBase<Derived> &matrix
         && (matrix.cols() == 1 || matrix.colStride() == matrix.rows());
 }
 
+/** Serializes Eigen array or matrix */
 template <typename Derived>
 typename std::enable_if<has_primitive_scalar<Derived>::value, void>::type
 serialize(serializer &ser, const std::string &key,
@@ -65,6 +71,7 @@ serialize(serializer &ser, const std::string &key,
     }
 }
 
+/** Deserializes Eigen array or matrix */
 template <typename Derived>
 typename std::enable_if<has_primitive_scalar<Derived>::value, void>::type
 deserialize(deserializer &ser, const std::string &key,

--- a/utilities/include/alps/serialization/eigen.hpp
+++ b/utilities/include/alps/serialization/eigen.hpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 1998-2018 ALPS Collaboration. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ * For use in publications, see ACKNOWLEDGE.TXT
+ */
+#pragma once
+
+#include <Eigen/Dense>
+#include <array>
+
+#include <alps/serialization/core.hpp>
+
+namespace alps { namespace serialization {
+
+template <typename Derived>
+struct has_primitive_scalar {
+    using _scalar_type = typename Eigen::internal::traits<Derived>::Scalar;
+    static const bool value = is_primitive<_scalar_type>::value;
+};
+
+template <typename Derived>
+typename std::enable_if<has_primitive_scalar<Derived>::value, void>::type
+serialize(serializer &ser, const std::string &key,
+          const Eigen::MatrixBase<Derived> &value)
+{
+    typedef Eigen::internal::traits<Derived> traits;
+    typedef typename traits::Scalar scalar_type;
+    typedef Eigen::Matrix<scalar_type, Derived::RowsAtCompileTime,
+                          Derived::ColsAtCompileTime> plain_matrix_type;
+
+    // Ensure that evaluated expression will be C-contiguous
+    if ((Derived::MaxRowsAtCompileTime != Eigen::Dynamic
+                    && Derived::MaxRowsAtCompileTime != value.rows())
+            || (Derived::MaxColsAtCompileTime != Eigen::Dynamic
+                    && Derived::MaxColsAtCompileTime != value.cols())
+            || ((Derived::Options & Eigen::RowMajor)
+                    && value.rows() != 1 && value.cols() != 1))
+        serialize(ser, key, plain_matrix_type(value));
+
+    // Evaluate to matrix or proxy object if already matrix
+    auto temp = value.eval();
+
+    if (Derived::ColsAtCompileTime == 1 || Derived::RowsAtCompileTime == 1) {
+        // Omit second dimension for simple vectors
+        std::array<size_t, 1> dims = {{(size_t)temp.size()}};
+        ser.write(key, ndview<const scalar_type>(temp.data(), dims.data(), 1));
+    } else {
+        // Eigen arrays are column-major
+        std::array<size_t, 2> dims = {{(size_t)temp.cols(), (size_t)temp.rows()}};
+        ser.write(key, ndview<const scalar_type>(temp.data(), dims.data(), 2));
+    }
+}
+
+template <typename T>
+typename std::enable_if<is_primitive<T>::value, void>::type
+deserialize(deserializer &ser, const std::string &key,
+            Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> &value)
+{
+    std::array<size_t, 2> shape = {{(size_t)value.cols(), (size_t)value.rows()}};
+    ser.read(key, ndview<T>(value.data(), shape.data(), shape.size()));
+}
+
+template <typename T>
+typename std::enable_if<is_primitive<T>::value, void>::type
+deserialize(deserializer &ser, const std::string &key,
+            Eigen::Matrix<T, Eigen::Dynamic, 1> &value)
+{
+    std::array<size_t, 1> shape = {{(size_t)value.rows()}};
+    ser.read(key, ndview<T>(value.data(), shape.data(), shape.size()));
+}
+
+template <typename T>
+typename std::enable_if<is_primitive<T>::value, void>::type
+deserialize(deserializer &ser, const std::string &key,
+            Eigen::Matrix<T, 1, Eigen::Dynamic> &value)
+{
+    std::array<size_t, 1> shape = {{(size_t)value.cols()}};
+    ser.read(key, ndview<T>(value.data(), shape.data(), shape.size()));
+}
+
+}}

--- a/utilities/include/alps/serialization/util.hpp
+++ b/utilities/include/alps/serialization/util.hpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 1998-2018 ALPS Collaboration. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ * For use in publications, see ACKNOWLEDGE.TXT
+ */
+#pragma once
+
+#include <string>
+
+#include <alps/serialization/core.hpp>
+
+namespace alps { namespace serialization {
+
+/**
+ * Allows RAII-type use of groups in serializer.
+ *
+ * Enters the specified group on construction of the sentry, and automatically
+ * leaves the group when the object is destroyed.  This also allows recovery in
+ * the case of soft exceptions.
+ *
+ *     void write_to_group(serializer &s, std::string name) {
+ *         internal::serializer_sentry group(s, name);
+ *         serialize(s, "first_item", 42);
+ *         serialize(s, "second_item", 4711);
+ *     } // exits group here
+ */
+struct serializer_sentry
+{
+    serializer_sentry(serializer &ser, const std::string &group)
+        : ser_(ser)
+        , group_(group)
+    {
+        if (group != "")
+            ser_.enter(group);
+    }
+
+    ~serializer_sentry()
+    {
+        if (group_ != "")
+            ser_.exit();
+    }
+
+private:
+    serializer &ser_;
+    std::string group_;
+};
+
+/**
+ * Allows RAII-type use of groups in deserializer.
+ *
+ * Enters the specified group on construction of the sentry, and automatically
+ * leaves the group when the object is destroyed.  This also allows recovery in
+ * the case of soft exceptions.
+ */
+struct deserializer_sentry
+{
+    deserializer_sentry(deserializer &ser, const std::string &group)
+        : ser_(ser)
+        , group_(group)
+    {
+        if (group != "")
+            ser_.enter(group);
+    }
+
+    ~deserializer_sentry()
+    {
+        if (group_ != "")
+            ser_.exit();
+    }
+
+private:
+    deserializer &ser_;
+    std::string group_;
+};
+
+}}


### PR DESCRIPTION
This adds the `alps::serialization` namespace.  The ALEA serialization and deserialization infrastructure is moved from `alps::alea` to this namespace, and ALEA imports those back into the `alps::alea` namespace for backwards compatibility.

The tests for serializer remain in the `alea` package for now, since its the only user.

This is step 1 in decoupling parameters from HDF5.