### PR TITLE
Fix move semantics of tensor

### DIFF
--- a/utilities/include/alps/numeric/tensors/data_storage.hpp
+++ b/utilities/include/alps/numeric/tensors/data_storage.hpp
@@ -54,15 +54,12 @@ namespace alps {
         };
         /// Move assignment
         data_storage<T, Cont>& operator=(data_storage<T, Cont>&& rhs) {
-          if(size() != rhs.size()) {
-            resize(rhs.size());
-          }
-          std::copy(rhs.data(), rhs.data() + rhs.size(), data());
+          data_ = std::move(rhs.data_);
           return *this;
         };
 
         /**
-         * General tensor assignment 
+         * General tensor assignment
          *
          * @tparam T2  - rhs value type
          * @tparam C2  - rhs storage container type

--- a/utilities/test/tensor_test.cpp
+++ b/utilities/test/tensor_test.cpp
@@ -92,7 +92,6 @@ TEST(TensorTest, TestCopyAssignments) {
   Eigen::MatrixXd M1 = Eigen::MatrixXd::Random(N, N);
   Eigen::MatrixXcd M2 = Eigen::MatrixXcd::Random(N, N);
   tensor<double, 2> T1(N, N);
-  tensor<double, 2> T3(T1);
   tensor<double, 2> T2(N, N);
   for(size_t i = 0; i< N; ++i) {
     for (size_t j = 0; j < N; ++j) {
@@ -107,6 +106,23 @@ TEST(TensorTest, TestCopyAssignments) {
   V1(0,0) = -15.0;
   V2 = V1;
   ASSERT_EQ(T2(0,0), -15.0);
+}
+
+TEST(TensorTest, TestMoveAssignments) {
+  size_t N = 10;
+  Eigen::MatrixXd M1 = Eigen::MatrixXd::Random(N, N);
+  Eigen::MatrixXd M2 = Eigen::MatrixXd::Random(N, N);
+  tensor<double, 2> T1(N, N);
+  tensor<double, 2> T2(N, N);
+  for(size_t i = 0; i< N; ++i) {
+    for (size_t j = 0; j < N; ++j) {
+      T1(i,j) = M1(i,j);
+      T2(i,j) = M2(i,j);
+    }
+  }
+  T2 = std::move(T1);
+  ASSERT_EQ(T1.size(), 0ul);
+  ASSERT_EQ(T2.matrix(), M1);
 }
 
 TEST(TensorTest, TestSlices) {


### PR DESCRIPTION
Current move assignment for `tensor` doesn't work as intended. For example, the following

```cpp
using alps::numerics;
tensor<double, 2> a(10, 10);
tensor<double, 2> b;
b = std::move(a);
```
actually copies data from `a` to `b`, instead of moving and invalidating `a`.

Here's a fix for `data_storage` that fixes the move of the storage. After the move, `a` will no longer hold data, and the data is transferred to `b`. However, it will leave the size information in `a` unchanged. This essentially left `a` to an invalid state.

Fixing this would require explicit treatments for different storage types. I would suggest that since the move semantics isn't frequently used we could keep it like this for now.

