### PR TITLE
Add missing cassert header

### DIFF
--- a/utilities/include/alps/numeric/tensors/view.hpp
+++ b/utilities/include/alps/numeric/tensors/view.hpp
@@ -7,6 +7,7 @@
 #ifndef ALPSCORE_GF_VIEW_H
 #define ALPSCORE_GF_VIEW_H
 
+#include <cassert>
 
 #include "data_storage.hpp"
 


### PR DESCRIPTION
Similar to #653. Looks like newer Eigen may have removed a `cassert` which is causing these failures.

Was seen while building on Ubuntu 22.04 + GCC 12 with Homebrew Eigen 5.0.0. Not seen on macOS.